### PR TITLE
Major Refactoring

### DIFF
--- a/Artisan.podspec
+++ b/Artisan.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Artisan'
-  s.version          = '1.0.6'
+  s.version          = '1.1.0'
   s.summary          = 'Artisan is a DSL, MVVM and Data Binding framework for Swift'
 
 # This description is used to generate tags and improve search results.

--- a/Artisan/Classes/Bond/LinkerProtocols.swift
+++ b/Artisan/Classes/Bond/LinkerProtocols.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-public protocol StatedMediator {
+public protocol AnyMediator {
     var bondingStates: [ViewBondingState] { get }
     var observables: [StateObservable] { get }
     func removeBond()
 }
 
-public protocol BondableMediator: class, Buildable, StatedMediator {
+public protocol BondableMediator: class, Buildable, AnyMediator {
     associatedtype View: NSObject
     var view: View? { get }
     func map(from view: View)

--- a/Artisan/Classes/Mediator/CellMediator.swift
+++ b/Artisan/Classes/Mediator/CellMediator.swift
@@ -27,16 +27,16 @@ public extension CellMediator {
     }
 }
 
-public protocol CollectionCellMediator: CellMediator {
+public protocol AnyCollectionCellMediator: CellMediator {
     func apply(cell: UICollectionReusableView)
 }
 
-public protocol TableCellMediator: CellMediator {
+public protocol AnyTableCellMediator: CellMediator {
     var index: String? { get }
     func apply(cell: UITableViewCell)
 }
 
-open class TableViewCellMediator<Cell: UITableViewCell>: ViewMediator<Cell>, TableCellMediator {
+open class TableCellMediator<Cell: UITableViewCell>: ViewMediator<Cell>, AnyTableCellMediator {
     public static var cellViewClass: AnyClass { Cell.self }
     public static var cellReuseIdentifier: String {
         let camelCaseName = String(describing: Cell.self).filter { $0.isLetter || $0.isNumber }.camelCaseToSnakeCase()
@@ -94,7 +94,7 @@ open class TableViewCellMediator<Cell: UITableViewCell>: ViewMediator<Cell>, Tab
     }
 }
 
-open class CollectionViewCellMediator<Cell: UICollectionViewCell>: ViewMediator<Cell>, CollectionCellMediator {
+open class CollectionCellMediator<Cell: UICollectionViewCell>: ViewMediator<Cell>, AnyCollectionCellMediator {
     
     public static var cellViewClass: AnyClass { Cell.self }
     public static var cellReuseIdentifier: String {

--- a/Artisan/Classes/Mediator/EmptyCell.swift
+++ b/Artisan/Classes/Mediator/EmptyCell.swift
@@ -1,0 +1,25 @@
+//
+//  EmptyCell.swift
+//  Artisan
+//
+//  Created by Nayanda Haberty (ID) on 24/09/20.
+//
+
+import Foundation
+import UIKit
+
+public class EmptyTableCell: TableFragmentCell {
+    var preferedHeight: CGFloat = .automatic
+    
+    public override func calculatedCellHeight(for cellWidth: CGFloat) -> CGFloat {
+        return preferedHeight
+    }
+}
+
+public class EmptyCollectionCell: CollectionFragmentCell {
+    var preferedSize: CGSize = .automatic
+    
+    public override func calculatedCellSize(for collectionContentSize: CGSize) -> CGSize {
+        return preferedSize
+    }
+}

--- a/Artisan/Classes/Mediator/UICollectionView+Mediator.swift
+++ b/Artisan/Classes/Mediator/UICollectionView+Mediator.swift
@@ -28,7 +28,7 @@ extension UICollectionView {
         }
     }
     
-    public var cells: [CollectionCellMediator] {
+    public var cells: [AnyCollectionCellMediator] {
         get {
             mediator.sections.first?.cells ?? []
         }
@@ -80,21 +80,21 @@ extension UICollectionView {
     
     open class Section: Identifiable, Equatable {
         public var index: String?
-        public var cells: [CollectionCellMediator]
+        public var cells: [AnyCollectionCellMediator]
         public var cellCount: Int { cells.count }
         public var identifier: AnyHashable
         
-        public init(identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [CollectionCellMediator] = []) {
+        public init(identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [AnyCollectionCellMediator] = []) {
             self.identifier = identifier
             self.cells = cells
             self.index = index
         }
         
-        public func add(cell: CollectionCellMediator) {
+        public func add(cell: AnyCollectionCellMediator) {
             cells.append(cell)
         }
         
-        public func add(cells: [CollectionCellMediator]) {
+        public func add(cells: [AnyCollectionCellMediator]) {
             self.cells.append(contentsOf: cells)
         }
         
@@ -125,10 +125,10 @@ extension UICollectionView {
     
     public class SupplementedSection: Section {
         
-        public var header: CollectionCellMediator?
-        public var footer: CollectionCellMediator?
+        public var header: AnyCollectionCellMediator?
+        public var footer: AnyCollectionCellMediator?
         
-        public init(header: CollectionCellMediator? = nil, footer: CollectionCellMediator? = nil, identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [CollectionCellMediator] = []) {
+        public init(header: AnyCollectionCellMediator? = nil, footer: AnyCollectionCellMediator? = nil, identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [AnyCollectionCellMediator] = []) {
             self.header = header
             self.footer = footer
             super.init(identifier: identifier, index: index, cells: cells)

--- a/Artisan/Classes/Mediator/UICollectionView+Mediator.swift
+++ b/Artisan/Classes/Mediator/UICollectionView+Mediator.swift
@@ -8,6 +8,9 @@
 import Foundation
 import UIKit
 
+public typealias CollectionSection = UICollectionView.Section
+public typealias SupplementedCollectionSection = UICollectionView.SupplementedSection
+
 extension UICollectionView {
     
     public var mediator: UICollectionView.Mediator {
@@ -45,6 +48,26 @@ extension UICollectionView {
         set {
             mediator.reloadStrategy = newValue
         }
+    }
+    
+    public func appendWithCell(_ builder: (CollectionCellBuilder) -> Void) {
+        guard !sections.isEmpty else {
+            buildWithCells(builder)
+            return
+        }
+        let collectionBuilder = CollectionCellBuilder(sections: sections)
+        builder(collectionBuilder)
+        sections = collectionBuilder.build()
+    }
+    
+    public func buildWithCells(withFirstSectionId firstSection: String, _ builder: (CollectionCellBuilder) -> Void) {
+        buildWithCells(withFirstSection: Section(identifier: firstSection), builder)
+    }
+    
+    public func buildWithCells(withFirstSection firstSection: UICollectionView.Section? = nil, _ builder: (CollectionCellBuilder) -> Void) {
+        let collectionBuilder = CollectionCellBuilder(section: firstSection ?? Section(identifier: "first_section"))
+        builder(collectionBuilder)
+        sections = collectionBuilder.build()
     }
     
     public func whenDidReloadCells(then: ((Bool) -> Void)?) {

--- a/Artisan/Classes/Mediator/UITableView+Mediator.swift
+++ b/Artisan/Classes/Mediator/UITableView+Mediator.swift
@@ -28,7 +28,7 @@ extension UITableView {
         }
     }
     
-    public var cells: [TableCellMediator] {
+    public var cells: [AnyTableCellMediator] {
         get {
             mediator.sections.first?.cells ?? []
         }
@@ -120,21 +120,21 @@ extension UITableView {
     
     open class Section: Identifiable, Equatable {
         public var index: String?
-        public var cells: [TableCellMediator]
+        public var cells: [AnyTableCellMediator]
         public var cellCount: Int { cells.count }
         public var identifier: AnyHashable
         
-        public init(identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [TableCellMediator] = []) {
+        public init(identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [AnyTableCellMediator] = []) {
             self.identifier = identifier
             self.cells = cells
             self.index = index
         }
         
-        public func add(cell: TableCellMediator) {
+        public func add(cell: AnyTableCellMediator) {
             cells.append(cell)
         }
         
-        public func add(cells: [TableCellMediator]) {
+        public func add(cells: [AnyTableCellMediator]) {
             self.cells.append(contentsOf: cells)
         }
         
@@ -167,7 +167,7 @@ extension UITableView {
         
         public var title: String
         
-        public init(title: String, identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [TableCellMediator] = []) {
+        public init(title: String, identifier: AnyHashable = String.randomString(), index: String? = nil, cells: [AnyTableCellMediator] = []) {
             self.title = title
             super.init(identifier: identifier, index: index, cells: cells)
         }

--- a/Artisan/Classes/Mediator/UITableView+Mediator.swift
+++ b/Artisan/Classes/Mediator/UITableView+Mediator.swift
@@ -8,6 +8,9 @@
 import Foundation
 import UIKit
 
+public typealias TableSection = UITableView.Section
+public typealias TableTitledSection = UITableView.TitledSection
+
 extension UITableView {
     
     public var mediator: UITableView.Mediator {
@@ -54,6 +57,26 @@ extension UITableView {
         set {
             mediator.reloadStrategy = newValue
         }
+    }
+    
+    public func appendWithCell(_ builder: (TableCellBuilder) -> Void) {
+        guard !sections.isEmpty else {
+            buildWithCells(builder)
+            return
+        }
+        let collectionBuilder = TableCellBuilder(sections: sections)
+        builder(collectionBuilder)
+        sections = collectionBuilder.build()
+    }
+    
+    public func buildWithCells(withFirstSectionId firstSection: String, _ builder: (TableCellBuilder) -> Void) {
+        buildWithCells(withFirstSection: Section(identifier: firstSection), builder)
+    }
+    
+    public func buildWithCells(withFirstSection firstSection: UITableView.Section? = nil, _ builder: (TableCellBuilder) -> Void) {
+        let collectionBuilder = TableCellBuilder(section: firstSection ?? Section(identifier: "first_section"))
+        builder(collectionBuilder)
+        sections = collectionBuilder.build()
     }
     
     public func whenDidReloadCells(then: ((Bool) -> Void)?) {

--- a/Artisan/Classes/Mediator/ViewApplicator.swift
+++ b/Artisan/Classes/Mediator/ViewApplicator.swift
@@ -1,30 +1,30 @@
 //
-//  GenericCellMediator.swift
+//  GenericMediator.swift
 //  Artisan
 //
-//  Created by Nayanda Haberty (ID) on 24/09/20.
+//  Created by Nayanda Haberty on 29/01/21.
 //
 
 import Foundation
-import UIKit
 
-public class EmptyTableCell: TableFragmentCell {
-    var preferedHeight: CGFloat = .automatic
+public class ViewApplicator<View: UIView>: ViewMediator<View> {
+    var applicator: (View) -> Void
     
-    public override func calculatedCellHeight(for cellWidth: CGFloat) -> CGFloat {
-        return preferedHeight
+    public init(_ applicator: @escaping (View) -> Void) {
+        self.applicator = applicator
+    }
+    
+    required init() {
+        self.applicator = { _ in }
+    }
+    
+    open override func willApplying(_ view: View) {
+        super.willApplying(view)
+        applicator(view)
     }
 }
 
-public class EmptyCollectionCell: CollectionFragmentCell {
-    var preferedSize: CGSize = .automatic
-    
-    public override func calculatedCellSize(for collectionContentSize: CGSize) -> CGSize {
-        return preferedSize
-    }
-}
-
-public class GenericTableCellMediator<Cell: UITableViewCell>: TableViewCellMediator<Cell> {
+public class TableCellApplicator<Cell: UITableViewCell>: TableCellMediator<Cell> {
     var applicator: (Cell) -> Void
     
     public init(_ applicator: @escaping (Cell) -> Void) {
@@ -41,7 +41,7 @@ public class GenericTableCellMediator<Cell: UITableViewCell>: TableViewCellMedia
     }
 }
 
-public class GenericCollectionCellMediator<Cell: UICollectionViewCell>: CollectionViewCellMediator<Cell> {
+public class CollectionCellApplicator<Cell: UICollectionViewCell>: CollectionCellMediator<Cell> {
     var applicator: (Cell) -> Void
     
     public init(_ applicator: @escaping (Cell) -> Void) {

--- a/Artisan/Classes/Mediator/ViewMediator.swift
+++ b/Artisan/Classes/Mediator/ViewMediator.swift
@@ -8,13 +8,13 @@
 import Foundation
 import UIKit
 
-extension StatedMediator {
+extension AnyMediator {
     
     func extractBondings(from mirror: Mirror, into states: inout [ViewBondingState]) {
         for child in mirror.children {
             if let bondings = child.value as? ViewBondingState {
                 states.append(bondings)
-            } else if let mediator = child.value as? StatedMediator {
+            } else if let mediator = child.value as? AnyMediator {
                 states.append(contentsOf: mediator.bondingStates)
             }
         }
@@ -38,7 +38,7 @@ extension StatedMediator {
         for child in mirror.children {
             if let stateObservable = child.value as? StateObservable {
                 states.append(stateObservable)
-            } else if let mediator = child.value as? StatedMediator {
+            } else if let mediator = child.value as? AnyMediator {
                 states.append(contentsOf: mediator.observables)
             }
         }
@@ -126,7 +126,7 @@ open class ViewMediator<View: NSObject>: NSObject, BondableMediator {
     open func didLoosingBond(with view: View?) { }
     
     open func bonding(with view: View) {
-        (view.getMediator() as? StatedMediator)?.removeBond()
+        (view.getMediator() as? AnyMediator)?.removeBond()
         if let cell = view as? TableFragmentCell {
             cell.mediator = self
         } else if let cell = view as? CollectionFragmentCell {

--- a/Artisan/Classes/Model/ArtisanError.swift
+++ b/Artisan/Classes/Model/ArtisanError.swift
@@ -35,4 +35,11 @@ extension ArtisanError {
             failureReason: failureReason
         )
     }
+    
+    static func whenDiffReloading(failureReason: String? = nil) -> ArtisanError {
+        .init(
+            errorDescription: "Artisan Error: Error when reload by difference",
+            failureReason: failureReason
+        )
+    }
 }

--- a/Artisan/Classes/Plan/FragmentCell.swift
+++ b/Artisan/Classes/Plan/FragmentCell.swift
@@ -24,7 +24,7 @@ open class TableFragmentCell: UITableViewCell, FragmentCell {
             _layoutPhase = newValue
         }
     }
-    var mediator: StatedMediator?
+    var mediator: AnyMediator?
     
     var layouted: Bool = false
     
@@ -108,7 +108,7 @@ open class CollectionFragmentCell: UICollectionViewCell, FragmentCell {
             _layoutPhase = newValue
         }
     }
-    var mediator: StatedMediator?
+    var mediator: AnyMediator?
     
     var layouted: Bool = false
     

--- a/Artisan/Classes/Utilities/CellModelBuilder.swift
+++ b/Artisan/Classes/Utilities/CellModelBuilder.swift
@@ -31,7 +31,7 @@ public class TableCellBuilder {
     }
     
     @discardableResult
-    public func next<Cell: TableCellMediator, Item>(mediatorType: Cell.Type, fromItems items: [Item], _ builder: (inout Cell, Item) -> Void) -> TableCellBuilder {
+    public func next<Cell: AnyTableCellMediator, Item>(mediatorType: Cell.Type, fromItems items: [Item], _ builder: (inout Cell, Item) -> Void) -> TableCellBuilder {
         for item in items {
             var cell = Cell.init()
             builder(&cell, item)
@@ -41,12 +41,12 @@ public class TableCellBuilder {
     }
     
     @discardableResult
-    public func next<Cell: TableCellMediator, Item>(mediatorType: Cell.Type, fromItem item: Item, _ builder: (inout Cell, Item) -> Void) -> TableCellBuilder {
+    public func next<Cell: AnyTableCellMediator, Item>(mediatorType: Cell.Type, fromItem item: Item, _ builder: (inout Cell, Item) -> Void) -> TableCellBuilder {
         return next(mediatorType: mediatorType, fromItems: [item], builder)
     }
     
     @discardableResult
-    public func next<Cell: TableCellMediator>(mediatorType: Cell.Type, count: Int, _ builder: (inout Cell, Int) -> Void) -> TableCellBuilder {
+    public func next<Cell: AnyTableCellMediator>(mediatorType: Cell.Type, count: Int, _ builder: (inout Cell, Int) -> Void) -> TableCellBuilder {
         for index in 0..<count {
             var cell = Cell.init()
             builder(&cell, index)
@@ -58,7 +58,7 @@ public class TableCellBuilder {
     @discardableResult
     public func next<Cell: UITableViewCell, Item>(cellType: Cell.Type, fromItems items: [Item], _ builder: @escaping (Cell, Item) -> Void) -> TableCellBuilder {
         for item in items {
-            lastSection.add(cell: GenericTableCellMediator<Cell> {
+            lastSection.add(cell: TableCellApplicator<Cell> {
                 builder($0, item)
             })
         }
@@ -73,7 +73,7 @@ public class TableCellBuilder {
     @discardableResult
     public func next<Cell: UITableViewCell>(cellType: Cell.Type, count: Int, _ builder: @escaping (Cell, Int) -> Void) -> TableCellBuilder {
         for index in 0..<count {
-            lastSection.add(cell: GenericTableCellMediator<Cell> {
+            lastSection.add(cell: TableCellApplicator<Cell> {
                 builder($0, index)
             })
         }
@@ -129,7 +129,7 @@ public class CollectionCellBuilder {
     }
     
     @discardableResult
-    public func next<Cell: CollectionCellMediator, Item>(mediatorType: Cell.Type, fromItems items: [Item], _ builder: (inout Cell, Item) -> Void) -> CollectionCellBuilder {
+    public func next<Cell: AnyCollectionCellMediator, Item>(mediatorType: Cell.Type, fromItems items: [Item], _ builder: (inout Cell, Item) -> Void) -> CollectionCellBuilder {
         for item in items {
             var cell = Cell.init()
             builder(&cell, item)
@@ -139,12 +139,12 @@ public class CollectionCellBuilder {
     }
     
     @discardableResult
-    public func next<Cell: CollectionCellMediator, Item>(mediatorType: Cell.Type, fromItem item: Item, _ builder: (inout Cell, Item) -> Void) -> CollectionCellBuilder {
+    public func next<Cell: AnyCollectionCellMediator, Item>(mediatorType: Cell.Type, fromItem item: Item, _ builder: (inout Cell, Item) -> Void) -> CollectionCellBuilder {
         return next(mediatorType: mediatorType, fromItems: [item], builder)
     }
     
     @discardableResult
-    public func next<Cell: CollectionCellMediator>(mediatorType: Cell.Type, count: Int, _ builder: (inout Cell, Int) -> Void) -> CollectionCellBuilder {
+    public func next<Cell: AnyCollectionCellMediator>(mediatorType: Cell.Type, count: Int, _ builder: (inout Cell, Int) -> Void) -> CollectionCellBuilder {
         for index in 0..<count {
             var cell = Cell.init()
             builder(&cell, index)
@@ -156,7 +156,7 @@ public class CollectionCellBuilder {
     @discardableResult
     public func next<Cell: UICollectionViewCell, Item>(cellType: Cell.Type, fromItems items: [Item], _ builder: @escaping (Cell, Item) -> Void) -> CollectionCellBuilder {
         for item in items {
-            lastSection.add(cell: GenericCollectionCellMediator<Cell> {
+            lastSection.add(cell: CollectionCellApplicator<Cell> {
                 builder($0, item)
             })
         }
@@ -171,7 +171,7 @@ public class CollectionCellBuilder {
     @discardableResult
     public func next<Cell: UICollectionViewCell>(cellType: Cell.Type, count: Int, _ builder: @escaping (Cell, Int) -> Void) -> CollectionCellBuilder {
         for index in 0..<count {
-            lastSection.add(cell: GenericCollectionCellMediator<Cell> {
+            lastSection.add(cell: CollectionCellApplicator<Cell> {
                 builder($0, index)
             })
         }

--- a/Example/Artisan/Details/Cell/EventCollectionCell.swift
+++ b/Example/Artisan/Details/Cell/EventCollectionCell.swift
@@ -38,7 +38,7 @@ class EventCollectionCell: CollectionFragmentCell {
     }
 }
 
-class EventCollectionCellVM: CollectionViewCellMediator<EventCollectionCell> {
+class EventCollectionCellVM: CollectionCellMediator<EventCollectionCell> {
     @ObservableState var event: Event?
     @ViewState var bannerImage: UIImage?
     @ViewState var eventName: String?

--- a/Example/Artisan/Details/Cell/SimilarEventCell.swift
+++ b/Example/Artisan/Details/Cell/SimilarEventCell.swift
@@ -35,7 +35,7 @@ class SimilarEventCell: TableFragmentCell {
     }
 }
 
-class SimilarEventCellVM: TableViewCellMediator<SimilarEventCell> {
+class SimilarEventCellVM: TableCellMediator<SimilarEventCell> {
     typealias TapAction = (SimilarEventCellVM, Event) -> Void
     var service: EventService = MockEventService()
     

--- a/Example/Artisan/Home/Cell/EventCell.swift
+++ b/Example/Artisan/Home/Cell/EventCell.swift
@@ -76,7 +76,7 @@ class EventCell: TableFragmentCell {
     }
 }
 
-class EventCellVM<Cell: EventCell>: TableViewCellMediator<Cell> {
+class EventCellVM<Cell: EventCell>: TableCellMediator<Cell> {
     @ObservableState var event: Event?
     @ViewState var bannerImage: UIImage?
     @ViewState var eventName: String?

--- a/Example/Artisan/Home/Cell/KeywordCell.swift
+++ b/Example/Artisan/Home/Cell/KeywordCell.swift
@@ -37,7 +37,7 @@ class KeywordCell: TableFragmentCell {
     }
 }
 
-class KeywordCellVM: TableViewCellMediator<KeywordCell> {
+class KeywordCellVM: TableCellMediator<KeywordCell> {
     @ViewState var keyword: String?
     var delegate: KeywordCellMediatorDelegate?
     override func bonding(with view: KeywordCell) {

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -144,7 +144,7 @@
 		BAE453A15CC93D9864577A1FEDE4E0E7 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D92466A0F94C7542C1D7368BB099E07 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		BB6FAD952590EFD300B6BB9D /* UICollectionView+ReloadStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD8E2590EFD300B6BB9D /* UICollectionView+ReloadStrategy.swift */; };
 		BB6FAD962590EFD300B6BB9D /* UITableView+Mediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD8F2590EFD300B6BB9D /* UITableView+Mediator.swift */; };
-		BB6FAD972590EFD300B6BB9D /* GenericCellMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD902590EFD300B6BB9D /* GenericCellMediator.swift */; };
+		BB6FAD972590EFD300B6BB9D /* EmptyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD902590EFD300B6BB9D /* EmptyCell.swift */; };
 		BB6FAD982590EFD300B6BB9D /* CellMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD912590EFD300B6BB9D /* CellMediator.swift */; };
 		BB6FAD992590EFD300B6BB9D /* ViewMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD922590EFD300B6BB9D /* ViewMediator.swift */; };
 		BB6FAD9A2590EFD300B6BB9D /* UICollectionView+Mediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FAD932590EFD300B6BB9D /* UICollectionView+Mediator.swift */; };
@@ -183,6 +183,7 @@
 		BB6FAE092590F17500B6BB9D /* Planable+Edges.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FADFA2590F17500B6BB9D /* Planable+Edges.swift */; };
 		BB6FAE0A2590F17500B6BB9D /* Planable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FADFB2590F17500B6BB9D /* Planable+Extensions.swift */; };
 		BB6FAE0B2590F17500B6BB9D /* InsertableStackPlan+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6FADFC2590F17500B6BB9D /* InsertableStackPlan+Extensions.swift */; };
+		BBBE0B7425C395BA0051C3E0 /* ViewApplicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBE0B7325C395BA0051C3E0 /* ViewApplicator.swift */; };
 		BBF98C1B25936736002AF568 /* DiffReloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF98C1A25936736002AF568 /* DiffReloader.swift */; };
 		BBF98C2B2593B5CC002AF568 /* AnchorExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF98C2A2593B5CC002AF568 /* AnchorExtraction.swift */; };
 		BD4953074A12E769ED4E6C94F5E73694 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B191FCDE235BED8CFDEE881C72302B5 /* UIKit.framework */; };
@@ -454,7 +455,7 @@
 		BAE263041362D074978BB3B577DF0A05 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB6FAD8E2590EFD300B6BB9D /* UICollectionView+ReloadStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+ReloadStrategy.swift"; sourceTree = "<group>"; };
 		BB6FAD8F2590EFD300B6BB9D /* UITableView+Mediator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Mediator.swift"; sourceTree = "<group>"; };
-		BB6FAD902590EFD300B6BB9D /* GenericCellMediator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericCellMediator.swift; sourceTree = "<group>"; };
+		BB6FAD902590EFD300B6BB9D /* EmptyCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyCell.swift; sourceTree = "<group>"; };
 		BB6FAD912590EFD300B6BB9D /* CellMediator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellMediator.swift; sourceTree = "<group>"; };
 		BB6FAD922590EFD300B6BB9D /* ViewMediator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewMediator.swift; sourceTree = "<group>"; };
 		BB6FAD932590EFD300B6BB9D /* UICollectionView+Mediator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Mediator.swift"; sourceTree = "<group>"; };
@@ -494,6 +495,7 @@
 		BB6FADFB2590F17500B6BB9D /* Planable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Planable+Extensions.swift"; sourceTree = "<group>"; };
 		BB6FADFC2590F17500B6BB9D /* InsertableStackPlan+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "InsertableStackPlan+Extensions.swift"; sourceTree = "<group>"; };
 		BB9BF1BF4172F97ED5D0DF84A14D7008 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		BBBE0B7325C395BA0051C3E0 /* ViewApplicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewApplicator.swift; sourceTree = "<group>"; };
 		BBF98C1A25936736002AF568 /* DiffReloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReloader.swift; sourceTree = "<group>"; };
 		BBF98C2A2593B5CC002AF568 /* AnchorExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorExtraction.swift; sourceTree = "<group>"; };
 		BC215521BB1EC60C90136D00C8AAA7E7 /* UIImage+Compare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.h"; sourceTree = "<group>"; };
@@ -910,13 +912,14 @@
 			isa = PBXGroup;
 			children = (
 				BB6FAD912590EFD300B6BB9D /* CellMediator.swift */,
-				BB6FAD902590EFD300B6BB9D /* GenericCellMediator.swift */,
+				BBBE0B7325C395BA0051C3E0 /* ViewApplicator.swift */,
+				BBF98C1A25936736002AF568 /* DiffReloader.swift */,
+				BB6FAD902590EFD300B6BB9D /* EmptyCell.swift */,
 				BB6FAD932590EFD300B6BB9D /* UICollectionView+Mediator.swift */,
 				BB6FAD8E2590EFD300B6BB9D /* UICollectionView+ReloadStrategy.swift */,
 				BB6FAD8F2590EFD300B6BB9D /* UITableView+Mediator.swift */,
 				BB6FAD942590EFD300B6BB9D /* UITableView+ReloadStrategy.swift */,
 				BB6FAD922590EFD300B6BB9D /* ViewMediator.swift */,
-				BBF98C1A25936736002AF568 /* DiffReloader.swift */,
 			);
 			path = Mediator;
 			sourceTree = "<group>";
@@ -1708,6 +1711,7 @@
 				BB6FAD952590EFD300B6BB9D /* UICollectionView+ReloadStrategy.swift in Sources */,
 				BB6FAE002590F17500B6BB9D /* PlanContext.swift in Sources */,
 				BB6FADCC2590F03600B6BB9D /* LinkerProtocols.swift in Sources */,
+				BBBE0B7425C395BA0051C3E0 /* ViewApplicator.swift in Sources */,
 				BBF98C2B2593B5CC002AF568 /* AnchorExtraction.swift in Sources */,
 				BB6FADBA2590EFEB00B6BB9D /* Enumeration+Extensions.swift in Sources */,
 				BB6FAE0A2590F17500B6BB9D /* Planable+Extensions.swift in Sources */,
@@ -1732,7 +1736,7 @@
 				BBF98C1B25936736002AF568 /* DiffReloader.swift in Sources */,
 				BB6FADFF2590F17500B6BB9D /* UIView+Artisan.swift in Sources */,
 				BB6FAE072590F17500B6BB9D /* Planable+Dimensions.swift in Sources */,
-				BB6FAD972590EFD300B6BB9D /* GenericCellMediator.swift in Sources */,
+				BB6FAD972590EFD300B6BB9D /* EmptyCell.swift in Sources */,
 				BB6FADB62590EFEB00B6BB9D /* CellModelBuilder.swift in Sources */,
 				BB6FAD992590EFD300B6BB9D /* ViewMediator.swift in Sources */,
 				851D07C1E22DFD4EACF59E47175B1E63 /* Artisan-dummy.m in Sources */,

--- a/Example/Tests/CellContainerMediatorSpec.swift
+++ b/Example/Tests/CellContainerMediatorSpec.swift
@@ -129,7 +129,7 @@ class CellContainerMediatorSpec: QuickSpec {
     }
 }
 
-class DummyCollectionCellMediator: CollectionCellMediator {
+class DummyCollectionCellMediator: AnyCollectionCellMediator {
     var id: String = .randomString()
     var identifier: AnyHashable { id }
     static var cellViewClass: AnyClass = UICollectionReusableView.self
@@ -148,7 +148,7 @@ class DummyCollectionCellMediator: CollectionCellMediator {
     }
 }
 
-class DummyTableCell: TableCellMediator {
+class DummyTableCell: AnyTableCellMediator {
     var id: String = .randomString()
     var index: String?
     var identifier: AnyHashable { id }

--- a/Example/Tests/CellMediatorBuilderSpec.swift
+++ b/Example/Tests/CellMediatorBuilderSpec.swift
@@ -91,10 +91,10 @@ class CellMediatorBuilderSpec: QuickSpec {
     }
 }
 
-class DummyCollectionMediator: CollectionViewCellMediator<UICollectionViewCell> {
+class DummyCollectionMediator: CollectionCellMediator<UICollectionViewCell> {
     var id: String?
 }
 
-class DummyTableMediator: TableViewCellMediator<UITableViewCell> {
+class DummyTableMediator: TableCellMediator<UITableViewCell> {
     var id: String?
 }

--- a/Example/Tests/CellMediatorSpec.swift
+++ b/Example/Tests/CellMediatorSpec.swift
@@ -15,25 +15,25 @@ import Nimble
 class CellMediatorSpec: QuickSpec {
     override func spec() {
         describe("table view model") {
-            var testableTMediator: TableViewCellMediator<UITableViewCell>!
+            var testableTMediator: TableCellMediator<UITableViewCell>!
             beforeEach {
                 testableTMediator = .init()
             }
             it("should have cell reuse identifier base on class name") {
-                expect(TableViewCellMediator<UITableViewCell>.cellReuseIdentifier).to(equal("artisan_managed_cell_ui_table_view_cell"))
+                expect(TableCellMediator<UITableViewCell>.cellReuseIdentifier).to(equal("artisan_managed_cell_ui_table_view_cell"))
             }
             it("should generate cell identifier") {
                 expect(testableTMediator.cellIdentifier as? String).toNot(beNil())
             }
             it("should check same model") {
                 expect(testableTMediator.isSameMediator(with: testableTMediator)).to(beTrue())
-                let otherTMediator: TableViewCellMediator<UITableViewCell> = .init()
+                let otherTMediator: TableCellMediator<UITableViewCell> = .init()
                 otherTMediator.cellIdentifier = testableTMediator.cellIdentifier
                 expect(testableTMediator.isSameMediator(with: otherTMediator)).to(beTrue())
                 expect(testableTMediator.isNotSameMediator(with: otherTMediator)).to(beFalse())
             }
             it("should know different model") {
-                let otherTMediator: TableViewCellMediator<UITableViewCell> = .init()
+                let otherTMediator: TableCellMediator<UITableViewCell> = .init()
                 while otherTMediator.cellIdentifier == testableTMediator.cellIdentifier {
                     otherTMediator.cellIdentifier = String.randomString()
                 }
@@ -41,31 +41,31 @@ class CellMediatorSpec: QuickSpec {
                 expect(testableTMediator.isNotSameMediator(with: otherTMediator)).to(beTrue())
             }
             it("should know different model class") {
-                let otherCMediator: CollectionViewCellMediator<UICollectionViewCell> = .init()
+                let otherCMediator: CollectionCellMediator<UICollectionViewCell> = .init()
                 expect(testableTMediator.isSameMediator(with: otherCMediator)).to(beFalse())
                 expect(testableTMediator.isNotSameMediator(with: otherCMediator)).to(beTrue())
             }
         }
         describe("collection view model") {
-            var testableCMediator: CollectionViewCellMediator<UICollectionViewCell>!
+            var testableCMediator: CollectionCellMediator<UICollectionViewCell>!
             beforeEach {
                 testableCMediator = .init()
             }
             it("should have cell reuse identifier base on class name") {
-                expect(CollectionViewCellMediator<UICollectionViewCell>.cellReuseIdentifier).to(equal("artisan_managed_cell_ui_collection_view_cell"))
+                expect(CollectionCellMediator<UICollectionViewCell>.cellReuseIdentifier).to(equal("artisan_managed_cell_ui_collection_view_cell"))
             }
             it("should generate cell identifier") {
                 expect(testableCMediator.cellIdentifier as? String).toNot(beNil())
             }
             it("should check same model") {
                 expect(testableCMediator.isSameMediator(with: testableCMediator)).to(beTrue())
-                let otherCMediator: CollectionViewCellMediator<UICollectionViewCell> = .init()
+                let otherCMediator: CollectionCellMediator<UICollectionViewCell> = .init()
                 otherCMediator.cellIdentifier = testableCMediator.cellIdentifier
                 expect(testableCMediator.isSameMediator(with: otherCMediator)).to(beTrue())
                 expect(testableCMediator.isNotSameMediator(with: otherCMediator)).to(beFalse())
             }
             it("should know different model") {
-                let otherCMediator: CollectionViewCellMediator<UICollectionViewCell> = .init()
+                let otherCMediator: CollectionCellMediator<UICollectionViewCell> = .init()
                 while otherCMediator.cellIdentifier == testableCMediator.cellIdentifier {
                     otherCMediator.cellIdentifier = String.randomString()
                 }
@@ -73,7 +73,7 @@ class CellMediatorSpec: QuickSpec {
                 expect(testableCMediator.isNotSameMediator(with: otherCMediator)).to(beTrue())
             }
             it("should know different model class") {
-                let otherTMediator: TableViewCellMediator<UITableViewCell> = .init()
+                let otherTMediator: TableCellMediator<UITableViewCell> = .init()
                 expect(testableCMediator.isSameMediator(with: otherTMediator)).to(beFalse())
                 expect(testableCMediator.isNotSameMediator(with: otherTMediator)).to(beTrue())
             }


### PR DESCRIPTION
- StatedMediator now renamed to AnyMediator
- CollectionCellMediator now renamed to AnyCollectionCellMediator
- TableCellMediator now renamed to AnyTableCellMediator
- CollectionViewCellMediator now renamed to CollectionCellMediator
- TableViewCellMediator now renamed to TableCellMediator
- GenericCollectionCellMediator now renamed to CollectionCellApplicator
- GenericTableCellMediator now renamed to TableCellApplicator
- DiffReloader now will not crash the app if the identifier is duplicated
- TableView and CollectionView now have build cells method