### PR TITLE
Binding Improvement

### DIFF
--- a/Artisan.podspec
+++ b/Artisan.podspec
@@ -38,8 +38,8 @@ Pod::Spec.new do |s|
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'Draftsman', '~> 3.0.4'
-  s.dependency 'Pharos', '~> 2.3.1'
+  s.dependency 'Draftsman', '~> 3.0.6'
+  s.dependency 'Pharos', '~> 2.3.5'
   s.dependency 'Builder', '~> 1.0.4'
   s.dependency 'DiffableDataSources', '~> 0.5.0'
   s.swift_version = '5.5'

--- a/Artisan/Classes/Binding/Observable+Binding.swift
+++ b/Artisan/Classes/Binding/Observable+Binding.swift
@@ -1,0 +1,21 @@
+//
+//  Observable+Binding.swift
+//  Artisan
+//
+//  Created by Nayanda Haberty on 03/07/22.
+//
+
+import Foundation
+import Pharos
+import Draftsman
+#if canImport(UIKit)
+
+extension Observable {
+    public func bindToPlan<View: Planned>(of view: View) -> Observed<State> {
+        whenDidSet { [weak view] _ in
+            guard let view = view else { return }
+            view.applyPlan()
+        }.observe(on: .main)
+    }
+}
+#endif

--- a/Artisan/Classes/Binding/ViewBindable+Retaining.swift
+++ b/Artisan/Classes/Binding/ViewBindable+Retaining.swift
@@ -1,0 +1,45 @@
+//
+//  ViewBindable+Retaining.swift
+//  Artisan
+//
+//  Created by Nayanda Haberty on 02/07/22.
+//
+
+import Foundation
+import Pharos
+import Draftsman
+#if canImport(UIKit)
+
+var bindingRetainerAssociatedKey = "Artisan_retain_binding"
+
+public extension ViewBindable {
+    
+    internal var bindingRetainer: Retainer {
+        guard let retainer = objc_getAssociatedObject(self, &bindingRetainerAssociatedKey) as? Retainer else {
+            let newRetainer = Retainer()
+            objc_setAssociatedObject(self, &bindingRetainerAssociatedKey, newRetainer, .OBJC_ASSOCIATION_RETAIN)
+            return newRetainer
+        }
+        return retainer
+    }
+}
+
+public typealias BindBuilder = ArrayBuilder<BindRetainable>
+public typealias BindRetainables = [BindRetainable]
+
+public protocol BindRetainable {
+    @discardableResult
+    func whileBind<View: ViewBindable>(with viewBindable: View) -> Invokable
+    func observe(on dispatcher: DispatchQueue) -> Self
+    func asynchronously() -> Self
+}
+
+extension BindRetainable where Self: ObservedSubject {
+    @discardableResult
+    public func whileBind<View: ViewBindable>(with viewBindable: View) -> Invokable {
+        retained(by: viewBindable.bindingRetainer)
+    }
+}
+
+extension Observed: BindRetainable { }
+#endif

--- a/Artisan/Classes/Extensions/UIView+Extensions.swift
+++ b/Artisan/Classes/Extensions/UIView+Extensions.swift
@@ -28,69 +28,21 @@ class UIControlAction {
 }
 
 public extension UIControl {
-    func whenDidTriggered(by event: UIControl.Event, do action: @escaping (UIControl) -> Void) {
-        let controlAction = UIControlAction(action)
-        addTarget(controlAction, action: #selector(UIControlAction.invoke(by:)), for: event)
-        objc_setAssociatedObject(
-            self,
-            String(ObjectIdentifier(self).hashValue)
-            + String(event.rawValue)
-            , controlAction,
-            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-        )
-    }
     
-    func whenDidTriggered<Object: AnyObject>(
-        by event: UIControl.Event,
-        invoke object: Object,
-        method: @escaping (Object) -> (UIControl) -> Void) {
-            let controlAction = UIControlAction { [weak object] control in
-                guard let object = object else { return }
-                method(object)(control)
-            }
-            addTarget(controlAction, action: #selector(UIControlAction.invoke(by:)), for: event)
-            objc_setAssociatedObject(
-                self,
-                String(ObjectIdentifier(self).hashValue)
-                + String(ObjectIdentifier(object).hashValue)
-                + String(event.rawValue)
-                , controlAction,
-                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-            )
-        }
-    
+    @available(*, deprecated, message: "Use whenDidTriggered from Pharos instead")
     func whenValueChanged(do action: @escaping (UIControl) -> Void) {
-        whenDidTriggered(by: .valueChanged, do: action)
+        whenDidTriggered(by: .valueChanged) { changes in
+            guard let control = changes.source as? UIControl else { return }
+            action(control)
+        }.retain()
     }
     
+    @available(*, deprecated, message: "Use whenDidTriggered from Pharos instead")
     func whenValueChanged<Object: AnyObject>(invoke object: Object, method: @escaping (Object) -> (UIControl) -> Void) {
-        whenDidTriggered(by: .valueChanged, invoke: object, method: method)
-    }
-}
-
-public extension UIButton {
-    func whenDidTapped(do action: @escaping (UIButton) -> Void) {
-        whenDidTriggered(by: .touchUpInside, do: { control in
-            guard let button = control as? UIButton else { return }
-            action(button)
-        })
-    }
-    
-    func whenDidTapped<Object: AnyObject>(invoke object: Object, method: @escaping (Object) -> (UIButton) -> Void) {
-        let controlAction = UIControlAction { [weak object] control in
-            guard let object = object, let button = control as? UIButton else { return }
-            method(object)(button)
-        }
-        let event: UIControl.Event = .touchUpInside
-        addTarget(controlAction, action: #selector(UIControlAction.invoke(by:)), for: event)
-        objc_setAssociatedObject(
-            self,
-            String(ObjectIdentifier(self).hashValue)
-            + String(ObjectIdentifier(object).hashValue)
-            + String(event.rawValue)
-            , controlAction,
-            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-        )
+        whenDidTriggered(by: .valueChanged) { [weak object] changes in
+            guard let object = object, let control = changes.source as? UIControl else { return }
+            method(object)(control)
+        }.retain()
     }
 }
 #endif

--- a/Example/Artisan/Details/Component/EventCollectionCell.swift
+++ b/Example/Artisan/Details/Component/EventCollectionCell.swift
@@ -72,16 +72,11 @@ class EventCollectionCell: UICollectionPlannedCell, ViewBindable {
         applyPlan()
     }
     
-    func viewNeedBind(with model: Model) {
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.bannerImageObservable
             .relayChanges(to: banner.bindables.image)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventNameObservable
             .relayChanges(to: title.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
 }

--- a/Example/Artisan/Details/Component/EventHeaderView.swift
+++ b/Example/Artisan/Details/Component/EventHeaderView.swift
@@ -106,26 +106,15 @@ class EventHeaderView: UIPlannedView, ViewBindable {
         applyPlan()
     }
     
-    func viewNeedBind(with model: Model) {
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.bannerImageObservable
             .relayChanges(to: banner.bindables.image)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventNameObservable
             .relayChanges(to: title.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventDetailsObservable
             .relayChanges(to: subTitle.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventDateObservable
             .relayChanges(to: date.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
 }

--- a/Example/Artisan/Details/Component/SimilarEventView.swift
+++ b/Example/Artisan/Details/Component/SimilarEventView.swift
@@ -78,12 +78,10 @@ class SimilarEventView: UIPlannedView, ViewBindable {
         applyPlan()
     }
     
-    func viewNeedBind(with model: Model) {
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.eventsObservable
             .relayChanges(to: $events)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
 }
 

--- a/Example/Artisan/Details/Component/VM/EventCollectionCellVM.swift
+++ b/Example/Artisan/Details/Component/VM/EventCollectionCellVM.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Pharos
+import UIKit
 
 struct EventCollectionCellVM: EventCollectionCellViewModel {
     @Subject var event: Event?

--- a/Example/Artisan/Details/Component/VM/EventHeaderVM.swift
+++ b/Example/Artisan/Details/Component/VM/EventHeaderVM.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Pharos
+import UIKit
 
 struct EventHeaderVM: EventHeaderViewModel {
     @Subject var event: Event?

--- a/Example/Artisan/Details/EventDetailsScreen.swift
+++ b/Example/Artisan/Details/EventDetailsScreen.swift
@@ -57,23 +57,19 @@ class EventDetailsScreen: UIPlannedController, ViewBindable {
         super.viewDidLoad()
         view.backgroundColor = .background
         navigationController?.navigationBar.tintColor = .main
-        applyPlan()
+        eventBind()
     }
     
-    func viewWillBind(with newModel: Model, oldModel: Model?) {
-        $event
-            .whenDidSet { [unowned self] changes in
-                self.applyPlan()
-            }.observe(on: .main)
+    func eventBind() {
+        $event.bindToPlan(of: self)
             .asynchronously()
             .retained(by: self)
+            .fire()
     }
     
-    func viewNeedBind(with model: Model) {
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.eventObservable
             .relayChanges(to: $event)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
 }

--- a/Example/Artisan/Home/Component/EventCell.swift
+++ b/Example/Artisan/Home/Component/EventCell.swift
@@ -107,26 +107,15 @@ class EventCell: UITablePlannedCell, ViewBindable {
         applyPlan()
     }
     
-    func viewNeedBind(with model: Model) {
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.bannerImageObservable
             .relayChanges(to: banner.bindables.image)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventNameObservable
             .relayChanges(to: title.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventDetailsObservable
             .relayChanges(to: subTitle.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
         model.eventDateObservable
             .relayChanges(to: date.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
 }

--- a/Example/Artisan/Home/Component/KeywordCell.swift
+++ b/Example/Artisan/Home/Component/KeywordCell.swift
@@ -73,11 +73,11 @@ class KeywordCell: UITablePlannedCell, ViewBindable {
         applyPlan()
     }
     
-    func viewNeedBind(with model: Model) {
+    @Subject var keyword: String?
+    
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.keywordObservable
             .relayChanges(to: keywordLabel.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
 }

--- a/Example/Artisan/Home/Component/VM/EventCellVM.swift
+++ b/Example/Artisan/Home/Component/VM/EventCellVM.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Pharos
+import UIKit
 
 struct EventCellVM: EventCellViewModel {
     @Subject var event: Event?

--- a/Example/Artisan/Home/Component/VM/KeywordCellVM.swift
+++ b/Example/Artisan/Home/Component/VM/KeywordCellVM.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Pharos
+import UIKit
 
 // MARK: Delegate Protocol
 

--- a/Example/Artisan/Home/EventSearchScreen.swift
+++ b/Example/Artisan/Home/EventSearchScreen.swift
@@ -93,16 +93,16 @@ class EventSearchScreen: UIPlannedController, ViewBindable {
         setupNavigation()
     }
     
-    func viewNeedBind(with model: Model) {
+    @BindBuilder
+    func autoBinding(with model: Model) -> BindRetainables {
         model.searchPhraseBindable
             .bind(with: searchBar.bindables.text)
-            .observe(on: .main)
-            .retained(by: self)
+    }
+    
+    @BindBuilder
+    func autoFireBinding(with model: Model) -> BindRetainables {
         model.eventResultsObservable
             .relayChanges(to: $allResults)
-            .observe(on: .main)
-            .retained(by: self)
-            .fire()
     }
     
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Artisan (5.0.0):
     - Builder (~> 1.0.4)
     - DiffableDataSources (~> 0.5.0)
-    - Draftsman (~> 3.0.4)
-    - Pharos (~> 2.3.1)
+    - Draftsman (~> 3.0.6)
+    - Pharos (~> 2.3.5)
   - Builder (1.0.4)
   - Chary (1.0.1)
   - Clavier (2.0.1)
@@ -13,7 +13,7 @@ PODS:
   - DifferenceKit/Core (1.2.0)
   - DifferenceKit/UIKitExtension (1.2.0):
     - DifferenceKit/Core
-  - Draftsman (3.0.4):
+  - Draftsman (3.0.6):
     - Builder (~> 1.0.4)
     - Clavier (~> 2.0.1)
   - FBSnapshotTestCase (2.1.4):
@@ -33,7 +33,7 @@ PODS:
   - Nimble-Snapshots/Core (9.1.1):
     - iOSSnapshotTestCase (~> 6.0)
     - Nimble
-  - Pharos (2.3.1):
+  - Pharos (2.3.5):
     - Chary (~> 1.0.1)
   - Quick (5.0.1)
 
@@ -66,19 +66,19 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Artisan: db74ad3b9ed8f4b92d5de6dc7c837f0f89143a6f
+  Artisan: 3f3b52f5a3d9bd767ff15792f41a6e86714b4c22
   Builder: 9ac1a38cfe5e84ef85ba7c56613046eae34f8f1b
   Chary: d776f18c773a8193988deaff7da4e0321c3555a7
   Clavier: 7458ac5d634bc424c38de23cc484bcf69595a9ec
   DiffableDataSources: 1ddde2de1978cc02619b2c3bfafab20e68b57279
   DifferenceKit: 5659c430bb7fe45876fa32ce5cba5d6167f0c805
-  Draftsman: 13dc1b7482400d3f85b5cffcc4d34af1cb355d1c
+  Draftsman: fe416d9ec7af0fa9a29b78acb2dca539f8b335fc
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   Impose: ad14652aa687c41f3f4f72632fa8312eb37182a9
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Nimble-Snapshots: 881d47f238c5462f38ffcccb1747b17c633b2c18
-  Pharos: cc5b25a6df22cfc9817721b8e363deec4eab9268
+  Pharos: ffc037bc39173a30cfd05671d9368d0316d8e10f
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
 
 PODFILE CHECKSUM: 2b503ce11f0107075f746157f35c2d8474250fe4

--- a/Example/Pods/Draftsman/Draftsman/Classes/Utilities/Extensions/UIView+Extensions.swift
+++ b/Example/Pods/Draftsman/Draftsman/Classes/Utilities/Extensions/UIView+Extensions.swift
@@ -52,18 +52,94 @@ public extension UILabel {
         self.text = text
     }
     
-    convenience init(text: String?, font: UIFont) {
+    convenience init(text: String? = nil, font: UIFont) {
         self.init()
         self.text = text
         self.font = font
+    }
+    
+    convenience init(text: String? = nil, textColor: UIColor) {
+        self.init()
+        self.text = text
+        self.textColor = textColor
+    }
+    
+    convenience init(text: String? = nil, font: UIFont, textColor: UIColor) {
+        self.init()
+        self.text = text
+        self.font = font
+        self.textColor = textColor
+    }
+}
+
+public extension UITextField {
+    
+    convenience init(placeholder: String?) {
+        self.init()
+        self.placeholder = placeholder
+    }
+    
+    convenience init(text: String?, placeholder: String? = nil) {
+        self.init()
+        self.text = text
+        self.placeholder = placeholder
+    }
+    
+    convenience init(text: String? = nil, placeholder: String? = nil, font: UIFont) {
+        self.init()
+        self.text = text
+        self.placeholder = placeholder
+        self.font = font
+    }
+    
+    convenience init(text: String? = nil, placeholder: String? = nil, textColor: UIColor) {
+        self.init()
+        self.text = text
+        self.placeholder = placeholder
+        self.textColor = textColor
+    }
+    
+    convenience init(text: String? = nil, placeholder: String? = nil, font: UIFont, textColor: UIColor) {
+        self.init()
+        self.text = text
+        self.placeholder = placeholder
+        self.font = font
+        self.textColor = textColor
+    }
+}
+
+public extension UITextView {
+    
+    convenience init(text: String?) {
+        self.init()
+        self.text = text
+    }
+    
+    convenience init(text: String? = nil, font: UIFont) {
+        self.init(text: text)
+        self.font = font
+    }
+    
+    convenience init(text: String? = nil, textColor: UIColor) {
+        self.init()
+        self.text = text
+        self.textColor = textColor
+    }
+    
+    convenience init(text: String? = nil, font: UIFont, textColor: UIColor) {
+        self.init()
+        self.text = text
+        self.font = font
+        self.textColor = textColor
     }
 }
 
 public extension UIButton {
     
-    convenience init(text: String?) {
+    convenience init(text: String?, textColor: UIColor) {
         self.init()
         self.setTitle(text, for: .normal)
+        self.setTitleColor(textColor, for: .normal)
     }
 }
 #endif

--- a/Example/Pods/Draftsman/README.md
+++ b/Example/Pods/Draftsman/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="512" height="256" src="draftsman.png"/>
+  <img width="192" height="192" src="draftsman.png"/>
 </p>
 
 # Draftsman
@@ -36,14 +36,14 @@ Draftsman is available through [CocoaPods](https://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Draftsman', '~> 3.0.4'
+pod 'Draftsman', '~> 3.0.6'
 ```
 
 ### Swift Package Manager from XCode
 
 - Add it using XCode menu **File > Swift Package > Add Package Dependency**
 - Add **<https://github.com/hainayanda/Draftsman.git>** as Swift Package URL
-- Set rules at **version**, with **Up to Next Major** option and put **3.0.4** as its version
+- Set rules at **version**, with **Up to Next Major** option and put **3.0.6** as its version
 - Click next and wait
 
 ### Swift Package Manager from Package.swift
@@ -52,7 +52,7 @@ Add as your target dependency in **Package.swift**
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hainayanda/Draftsman.git", .upToNextMajor(from: "3.0.4"))
+    .package(url: "https://github.com/hainayanda/Draftsman.git", .upToNextMajor(from: "3.0.6"))
 ]
 ```
 

--- a/Example/Pods/Local Podspecs/Artisan.podspec.json
+++ b/Example/Pods/Local Podspecs/Artisan.podspec.json
@@ -21,10 +21,10 @@
   "source_files": "Artisan/Classes/**/*",
   "dependencies": {
     "Draftsman": [
-      "~> 3.0.4"
+      "~> 3.0.6"
     ],
     "Pharos": [
-      "~> 2.3.1"
+      "~> 2.3.5"
     ],
     "Builder": [
       "~> 1.0.4"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,8 +2,8 @@ PODS:
   - Artisan (5.0.0):
     - Builder (~> 1.0.4)
     - DiffableDataSources (~> 0.5.0)
-    - Draftsman (~> 3.0.4)
-    - Pharos (~> 2.3.1)
+    - Draftsman (~> 3.0.6)
+    - Pharos (~> 2.3.5)
   - Builder (1.0.4)
   - Chary (1.0.1)
   - Clavier (2.0.1)
@@ -13,7 +13,7 @@ PODS:
   - DifferenceKit/Core (1.2.0)
   - DifferenceKit/UIKitExtension (1.2.0):
     - DifferenceKit/Core
-  - Draftsman (3.0.4):
+  - Draftsman (3.0.6):
     - Builder (~> 1.0.4)
     - Clavier (~> 2.0.1)
   - FBSnapshotTestCase (2.1.4):
@@ -33,7 +33,7 @@ PODS:
   - Nimble-Snapshots/Core (9.1.1):
     - iOSSnapshotTestCase (~> 6.0)
     - Nimble
-  - Pharos (2.3.1):
+  - Pharos (2.3.5):
     - Chary (~> 1.0.1)
   - Quick (5.0.1)
 
@@ -66,19 +66,19 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Artisan: db74ad3b9ed8f4b92d5de6dc7c837f0f89143a6f
+  Artisan: 3f3b52f5a3d9bd767ff15792f41a6e86714b4c22
   Builder: 9ac1a38cfe5e84ef85ba7c56613046eae34f8f1b
   Chary: d776f18c773a8193988deaff7da4e0321c3555a7
   Clavier: 7458ac5d634bc424c38de23cc484bcf69595a9ec
   DiffableDataSources: 1ddde2de1978cc02619b2c3bfafab20e68b57279
   DifferenceKit: 5659c430bb7fe45876fa32ce5cba5d6167f0c805
-  Draftsman: 13dc1b7482400d3f85b5cffcc4d34af1cb355d1c
+  Draftsman: fe416d9ec7af0fa9a29b78acb2dca539f8b335fc
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   Impose: ad14652aa687c41f3f4f72632fa8312eb37182a9
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Nimble-Snapshots: 881d47f238c5462f38ffcccb1747b17c633b2c18
-  Pharos: cc5b25a6df22cfc9817721b8e363deec4eab9268
+  Pharos: ffc037bc39173a30cfd05671d9368d0316d8e10f
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
 
 PODFILE CHECKSUM: 2b503ce11f0107075f746157f35c2d8474250fe4

--- a/Example/Pods/Pharos/Pharos/Classes/Observable/Subject.swift
+++ b/Example/Pods/Pharos/Pharos/Classes/Observable/Subject.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @propertyWrapper
-public final class Subject<Wrapped>: BindableObservable<Wrapped> {
+public class Subject<Wrapped>: BindableObservable<Wrapped> {
     
     var _wrappedValue: Wrapped
     public var wrappedValue: Wrapped {

--- a/Example/Pods/Pharos/Pharos/Classes/UIControl/UIControl+Extensions.swift
+++ b/Example/Pods/Pharos/Pharos/Classes/UIControl/UIControl+Extensions.swift
@@ -1,0 +1,169 @@
+//
+//  UIControl+Extensions.swift
+//  Pharos
+//
+//  Created by Nayanda Haberty on 30/06/22.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+
+var controlActionAssociatedKey: String = "controlActionAssociatedKey"
+
+extension UIControl.Event: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue)
+    }
+}
+
+extension UIControl {
+    
+    var allEventsPair: [UIControl.Event: Selector] {
+        if #available(iOS 14.0, *) {
+            return [
+                .touchDown: #selector(UIControlAction.touchDown(by:)),
+                .touchDownRepeat: #selector(UIControlAction.touchDownRepeat(by:)),
+                .touchDragInside: #selector(UIControlAction.touchDragInside(by:)),
+                .touchDragOutside: #selector(UIControlAction.touchDragOutside(by:)),
+                .touchDragEnter: #selector(UIControlAction.touchDragEnter(by:)),
+                .touchDragExit: #selector(UIControlAction.touchDragExit(by:)),
+                .touchUpInside: #selector(UIControlAction.touchUpInside(by:)),
+                .touchUpOutside: #selector(UIControlAction.touchUpOutside(by:)),
+                .touchCancel: #selector(UIControlAction.touchCancel(by:)),
+                .valueChanged: #selector(UIControlAction.valueChanged(by:)),
+                .primaryActionTriggered: #selector(UIControlAction.primaryActionTriggered(by:)),
+                .menuActionTriggered: #selector(UIControlAction.menuActionTriggered(by:)),
+                .editingDidBegin: #selector(UIControlAction.editingDidBegin(by:)),
+                .editingChanged: #selector(UIControlAction.editingChanged(by:)),
+                .editingDidEnd: #selector(UIControlAction.editingDidEnd(by:)),
+                .editingDidEndOnExit: #selector(UIControlAction.editingDidEndOnExit(by:))
+            ]
+        } else {
+            return [
+                .touchDown: #selector(UIControlAction.touchDown(by:)),
+                .touchDownRepeat: #selector(UIControlAction.touchDownRepeat(by:)),
+                .touchDragInside: #selector(UIControlAction.touchDragInside(by:)),
+                .touchDragOutside: #selector(UIControlAction.touchDragOutside(by:)),
+                .touchDragEnter: #selector(UIControlAction.touchDragEnter(by:)),
+                .touchDragExit: #selector(UIControlAction.touchDragExit(by:)),
+                .touchUpInside: #selector(UIControlAction.touchUpInside(by:)),
+                .touchUpOutside: #selector(UIControlAction.touchUpOutside(by:)),
+                .touchCancel: #selector(UIControlAction.touchCancel(by:)),
+                .valueChanged: #selector(UIControlAction.valueChanged(by:)),
+                .primaryActionTriggered: #selector(UIControlAction.primaryActionTriggered(by:)),
+                .editingDidBegin: #selector(UIControlAction.editingDidBegin(by:)),
+                .editingChanged: #selector(UIControlAction.editingChanged(by:)),
+                .editingDidEnd: #selector(UIControlAction.editingDidEnd(by:)),
+                .editingDidEndOnExit: #selector(UIControlAction.editingDidEndOnExit(by:))
+            ]
+        }
+    }
+    
+    var allEvents: [UIControl.Event] {
+        if #available(iOS 14.0, *) {
+            return [
+                .touchDown,
+                .touchDownRepeat,
+                .touchDragInside,
+                .touchDragOutside,
+                .touchDragEnter,
+                .touchDragExit,
+                .touchUpInside,
+                .touchUpOutside,
+                .touchCancel,
+                .valueChanged,
+                .primaryActionTriggered,
+                .menuActionTriggered,
+                .editingDidBegin,
+                .editingChanged,
+                .editingDidEnd,
+                .editingDidEndOnExit
+            ]
+        } else {
+            return [
+                .touchDown,
+                .touchDownRepeat,
+                .touchDragInside,
+                .touchDragOutside,
+                .touchDragEnter,
+                .touchDragExit,
+                .touchUpInside,
+                .touchUpOutside,
+                .touchCancel,
+                .valueChanged,
+                .primaryActionTriggered,
+                .editingDidBegin,
+                .editingChanged,
+                .editingDidEnd,
+                .editingDidEndOnExit
+            ]
+        }
+    }
+    
+    var allTouchEvents: [UIControl.Event] {
+        [
+            .touchDown,
+            .touchDownRepeat,
+            .touchDragInside,
+            .touchDragOutside,
+            .touchDragEnter,
+            .touchDragExit,
+            .touchUpInside,
+            .touchUpOutside,
+            .touchCancel
+        ]
+    }
+    
+    var allEditingEvents: [UIControl.Event] {
+        [
+            .editingDidBegin,
+            .editingChanged,
+            .editingDidEnd,
+            .editingDidEndOnExit
+        ]
+    }
+}
+
+extension UIControl {
+    
+    public func whenDetectEvent(thenDo work: @escaping (Changes<UIControl.Event>) -> Void) -> Observed<UIControl.Event> {
+        getControlAction().eventObservable.whenDidSet(thenDo: work)
+    }
+    
+    public func whenDidTriggered(by event: UIControl.Event, thenDo work: @escaping (Changes<UIControl.Event>) -> Void) -> Observed<UIControl.Event> {
+        let eventUsed: [UIControl.Event]
+        if event == .allEvents {
+            eventUsed = allEvents
+        } else if event == .allTouchEvents {
+            eventUsed = allTouchEvents
+        } else if event == .allEditingEvents {
+            eventUsed = allEditingEvents
+        } else {
+            eventUsed = [event]
+        }
+        return getControlAction().eventObservable.onlyInclude {
+            eventUsed.contains($0.new)
+        }.whenDidSet(thenDo: work)
+    }
+    
+    public func whenDidTapped(thenDo work: @escaping (Changes<UIControl.Event>) -> Void) -> Observed<UIControl.Event> {
+        whenDidTriggered(by: .touchUpInside, thenDo: work)
+    }
+    
+    func getControlAction() -> UIControlAction {
+        guard let controlAction = objc_getAssociatedObject(self, &controlActionAssociatedKey) as? UIControlAction else {
+            let controlAction = UIControlAction()
+            let allPairs = allEventsPair
+            for event in allEvents {
+                guard let selector = allPairs[event] else { continue }
+                addTarget(controlAction, action: selector, for: event)
+            }
+            objc_setAssociatedObject(self, &controlActionAssociatedKey, controlAction, .OBJC_ASSOCIATION_RETAIN)
+            return controlAction
+        }
+        return controlAction
+    }
+}
+
+#endif

--- a/Example/Pods/Pharos/Pharos/Classes/UIControl/UIControlAction.swift
+++ b/Example/Pods/Pharos/Pharos/Classes/UIControl/UIControlAction.swift
@@ -1,0 +1,89 @@
+//
+//  UIControlAction.swift
+//  Pharos
+//
+//  Created by Nayanda Haberty on 30/06/22.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+
+class UIControlAction: NSObject {
+    @UIControlSubject var lastEvent: UIControl.Event = .allEvents
+    
+    var eventObservable: Observable<UIControl.Event> {
+        $lastEvent
+    }
+    
+    func invoked(by sender: UIControl, with event: UIControl.Event) {
+        _lastEvent.sender = sender
+        self.lastEvent = event
+    }
+    
+    @objc func touchDown(by sender: UIControl) {
+        invoked(by: sender, with: .touchDown)
+    }
+    
+    @objc func touchDownRepeat(by sender: UIControl) {
+        invoked(by: sender, with: .touchDownRepeat)
+    }
+    
+    @objc func touchDragInside(by sender: UIControl) {
+        invoked(by: sender, with: .touchDragInside)
+    }
+    
+    @objc func touchDragOutside(by sender: UIControl) {
+        invoked(by: sender, with: .touchDragOutside)
+    }
+    
+    @objc func touchDragEnter(by sender: UIControl) {
+        invoked(by: sender, with: .touchDragEnter)
+    }
+    
+    @objc func touchDragExit(by sender: UIControl) {
+        invoked(by: sender, with: .touchDragExit)
+    }
+    
+    @objc func touchUpInside(by sender: UIControl) {
+        invoked(by: sender, with: .touchUpInside)
+    }
+    
+    @objc func touchUpOutside(by sender: UIControl) {
+        invoked(by: sender, with: .touchUpOutside)
+    }
+    
+    @objc func touchCancel(by sender: UIControl) {
+        invoked(by: sender, with: .touchCancel)
+    }
+    
+    @objc func valueChanged(by sender: UIControl) {
+        invoked(by: sender, with: .valueChanged)
+    }
+    
+    @objc func primaryActionTriggered(by sender: UIControl) {
+        invoked(by: sender, with: .primaryActionTriggered)
+    }
+    
+    @available(iOS 14.0, *)
+    @objc func menuActionTriggered(by sender: UIControl) {
+        invoked(by: sender, with: .menuActionTriggered)
+    }
+    
+    @objc func editingDidBegin(by sender: UIControl) {
+        invoked(by: sender, with: .editingDidBegin)
+    }
+    
+    @objc func editingChanged(by sender: UIControl) {
+        invoked(by: sender, with: .editingChanged)
+    }
+    
+    @objc func editingDidEnd(by sender: UIControl) {
+        invoked(by: sender, with: .editingDidEnd)
+    }
+    
+    @objc func editingDidEndOnExit(by sender: UIControl) {
+        invoked(by: sender, with: .editingDidEndOnExit)
+    }
+}
+#endif

--- a/Example/Pods/Pharos/Pharos/Classes/UIControl/UIControlSubject.swift
+++ b/Example/Pods/Pharos/Pharos/Classes/UIControl/UIControlSubject.swift
@@ -1,0 +1,31 @@
+//
+//  UIControlSubject.swift
+//  Pharos
+//
+//  Created by Nayanda Haberty on 30/06/22.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+
+@propertyWrapper
+class UIControlSubject: Subject<UIControl.Event> {
+    
+    weak var sender: UIControl?
+    
+    public override var wrappedValue: UIControl.Event {
+        get {
+            super.wrappedValue
+        }
+        set {
+            relay(
+                changes: Changes(old: super.wrappedValue, new: newValue, source: sender ?? self),
+                context: PharosContext()
+            )
+        }
+    }
+    
+    override var projectedValue: BindableObservable<UIControl.Event> { self }
+}
+#endif

--- a/Example/Pods/Pharos/README.md
+++ b/Example/Pods/Pharos/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img width="256" height="256" src="Pharos.png"/>
+</p>
+
 # Pharos
 
 Pharos is an Observer pattern framework for Swift that utilizes `propertyWrapper`. It could help a lot when designing Apps using reactive programming. Under the hood, it utilize [Chary](https://github.com/hainayanda/Chary) as DispatchQueue utilities
@@ -39,7 +43,7 @@ pod 'Pharos'
 
 - Add it using XCode menu **File > Swift Package > Add Package Dependency**
 - Add **<https://github.com/hainayanda/Pharos.git>** as Swift Package URL
-- Set rules at **version**, with **Up to Next Major** option and put **2.3.1** as its version
+- Set rules at **version**, with **Up to Next Major** option and put **2.3.5** as its version
 - Click next and wait
 
 ### Swift Package Manager from Package.swift
@@ -48,7 +52,7 @@ Add as your target dependency in **Package.swift**
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/hainayanda/Pharos.git", .upToNextMajor(from: "2.3.1"))
+    .package(url: "https://github.com/hainayanda/Pharos.git", .upToNextMajor(from: "2.3.5"))
 ]
 ```
 
@@ -238,6 +242,24 @@ class MyClass {
     }
     
 }
+```
+
+## UIControl
+
+You can observe event in `UIControl` as long as in iOS by call `whenDetectEvent`, or by using `whenDidTriggered(by:)` if you want to observe specific event or for more specific `whenDidTapped` for touchUpInside event:
+
+```swift
+myButton.whenDetectEvent { changes in
+  print("new event: \(changes.new) form old event: \(changes.old)")
+}.retain()
+
+myButton.whenDidTriggered(by: .touchDown) { _ in
+  print("someone touch down on this button")
+}.retain()
+
+myButton.whenDidTapped { _ in
+  print("someone touch up on this button")
+}.retain()
 ```
 
 ## Bindable

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,987 +7,970 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00A0507B6790C6C9D397AA7A25642B61 /* PrettySyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD742B226C7AECA5E6FC740C01AE551 /* PrettySyntax.swift */; };
-		0119530EBE8BC6CB1749E867B1D799A4 /* Scopable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E43DF8882DC7045E549106933310FC /* Scopable.swift */; };
-		01236C984BBB2918575C35713E2E08B4 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910BF5CAB2F64C252ED3133D0C7E3AA0 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		0219E278998DADCA6EF6CB9341079DC5 /* Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF30E9C5AEB4917A133334A432B35F3E /* Publisher.swift */; };
-		0240801B9D73582505BE11E5F57B8851 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
+		0008736FDE0C107143F49A74024EA27D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
+		00A0507B6790C6C9D397AA7A25642B61 /* PrettySyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3AC22A74BF5FD2CACCE09BE89A3EE3 /* PrettySyntax.swift */; };
+		0119530EBE8BC6CB1749E867B1D799A4 /* Scopable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0295041581E98C152C6EAA14C48F97 /* Scopable.swift */; };
+		01236C984BBB2918575C35713E2E08B4 /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1B40929DF06C32BF05A995C0D946F8 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		027D118A764F6A3FA64C690854E275EF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		02C46487477F445C4DA95C283CECDDAD /* BindableCollection+UISlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50932CBD0F89EC874A1D690E202EFF00 /* BindableCollection+UISlider.swift */; };
-		036D95FA11B861BF957FD1B24BA6645C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		057C1964EBAFCBC649F8012723CDADF5 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB938A476F8019D4D145BC31AE3E614C /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		0650AF0DB8DE333CE5D99D704E29AC02 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795C671C529F20CE73E4721AAB8F6809 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		080AF38AC0F35D3DE6F5283FA1D97659 /* ClavierLayoutGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2484281E8798BEB07CCB1F592A21BF8 /* ClavierLayoutGuide.swift */; };
-		088A5A88342D60B6FCFAEADBF0749220 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481AB0A8186CFE0CAB0B664C83E7ABE1 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		09796942E62FDC0EC6D0C793249D1C2C /* LayoutAxisAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467B43AAF430D3A0043CEC7ACEE9BD83 /* LayoutAxisAnchor.swift */; };
-		09D4B856CFEA59F4E16AB91D1F06D50C /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 814D6D5CAF570678DCA959940879DC39 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		0AB84C171BE96A1EA8335B7B5F364D34 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = C22B0DD847385FFBA9A7D93E318F35A7 /* FBSnapshotTestCase.m */; };
-		0BAC760A19A0F7BAD74264AA4DDDD679 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30667DFA8C29A058183C43DA2B15613A /* World+DSL.swift */; };
+		03D16E6A4CCD534E0E79FD4E0330BFB9 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B340E7679E814ABA2670F1BCD6D63862 /* UIView+Extensions.swift */; };
+		057C1964EBAFCBC649F8012723CDADF5 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3FF6B6B6C9922767CCAE37D2DC3486 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		0650AF0DB8DE333CE5D99D704E29AC02 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB09A11566CF986AD48C6549F1DF6FE /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		088A5A88342D60B6FCFAEADBF0749220 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDEFBBE383CEF0113F6862E05191F60 /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		08E0E6C68904008ADB77F20FB4BF6B94 /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5150628D0C3DDF4CE1EDDBE64810EF1 /* Changeset.swift */; };
+		097698EE3E5EB4F6069AA2700FFCAF94 /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF2C29F96615B40A37A0CD796794FA8 /* ContentEquatable.swift */; };
+		09D4B856CFEA59F4E16AB91D1F06D50C /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = A554CAFF68A1670E54D9A208FBEAC439 /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		09E9AF9AD6463B8D1474669ED9695C80 /* StackCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5706ABA08EAE92689544B4A57E2BF8 /* StackCompatible.swift */; };
+		0B751D880318CC75B0CCAD223A81A041 /* MergedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBBCE1557736117F9087022832E70CE /* MergedObservable.swift */; };
+		0BAC760A19A0F7BAD74264AA4DDDD679 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE8FF5F1C49D5792C32803D3505E4F2 /* World+DSL.swift */; };
 		0BCD36A9D7B12BA02B78A4D3309C5CD7 /* Maker+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94918E91CBA2E9CA0C34659AB6BA21E /* Maker+Extensions.swift */; };
-		0E398EF6297FFF6CC9BC74421BF1712D /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB96A42E6A29814E9993D065AE489B0C /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		0ED5A2370B4E4EB32E02579E1DDFE41D /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 80F3FB96FA13DB499426A23FA7816700 /* UIImage+Compare.m */; };
-		0F776B26BC641CB895C2E7D961C71152 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22FC8E5CBDFF2E5987E05D43ED99C14 /* ExampleHooks.swift */; };
-		108889297C9A0CD155B03BFA4E1D9FB4 /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C8B34DB23A19B22E3DAE3E50BEBBCDD /* UIImage+Diff.m */; };
+		0E398EF6297FFF6CC9BC74421BF1712D /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 678AF299CA04FAD3698E4BC6CEDE6871 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		0F776B26BC641CB895C2E7D961C71152 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8115C8FCE56D8B08764BAFEBF357213 /* ExampleHooks.swift */; };
+		1004587BDF3D7FD1834B2C31157CFDA1 /* BindableCollection+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AD3D9B819ECE13AACD57CEF8CA9C4B /* BindableCollection+UIButton.swift */; };
 		1250A7DF6D4922FF36BBEC34BB75FEE7 /* Methods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E25634F9115E23F57F339AC8B1A3B9 /* Methods.swift */; };
-		13C32177B632C72E7503BB78AB9A48D2 /* ImposerCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230D8ED669AC0AA65B645BCEC992B8E5 /* ImposerCompat.swift */; };
-		154A42D3BBF847E3C2C7A6BB4EFAEE84 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC3E6EF36C612C433233DEA6F14132A /* DSL.swift */; };
-		17101CF579A9D04C357C0D5FC85A4EC7 /* RelayInvoker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166ADDACFA37CB20B20D7C17BFD3270B /* RelayInvoker.swift */; };
-		19A2BC7DB952645642890240B65A0FD8 /* HaveValidDynamicTypeSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD10CCC395D25CD767B25B745C69822 /* HaveValidDynamicTypeSnapshot.swift */; };
-		19A8009537BCAD56435B2DDC620B29AA /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 560F0259FE9CF1CD6C1CB28DB49CECFF /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1B3A98A4E9BA1E64ABC90BE4000EC542 /* MergedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A05905564051BFAA696F2E24B322369 /* MergedObservable.swift */; };
-		1B5648DECACC2C478440DD19516ADCC5 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89A78F0D4B73383F387FE43B9A8081E /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		1C469C17A0E35E4508F74FEB1EDA586C /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A5AB4EAB0E7A99B017DA9E4D740E04 /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		1C685A13B605387826E6B4759CFD34C3 /* Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = F153ECF4DEE5575D636C2B522BB6478E /* Axis.swift */; };
-		1C820F77442AB16B7C1B6C1275339E3D /* iOSSnapshotTestCase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E3D399F3A1E2617F98BD948AF3555BB /* iOSSnapshotTestCase-dummy.m */; };
-		1D36043A36DAD2DAD85E9888A979828D /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = B06E2BE5402C4DED46CE9233092922C1 /* UIImage+Snapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1DD09AA22EA8ECE7F0CFCB870C5B3DC5 /* Clavier-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B52A1D267E4306D38FBC60311C53596D /* Clavier-dummy.m */; };
-		1E4CAC9687D0CDD2099DD07647FC1CBF /* AnchorExtractable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7B96FFF648DD539AAF8785422B9038 /* AnchorExtractable.swift */; };
-		1F84FE646CD1D7BAFFB58C243277AFF8 /* FBSnapshotTestCase-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 65E8B2D287DC125B5C365739F1B490BA /* FBSnapshotTestCase-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		207866DD86EDE603026D5AEDAF5ABE44 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 61D212BDC8D8434D70AE6958814A8AF3 /* QuickConfiguration.m */; };
-		21F3408E9BD0BE7C7A9FFBF43B4F28A0 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = F9408342CC9ECC49567A9B4ECACB23BA /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2223D9864ED3F01713DA2180EF7190B9 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24731B08BF7778703311E0388B647FC6 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		2304247E6E65AA1F76F281E51BB67C30 /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B25CDE8AA99BF58EF8602FC867699A /* AnyDifferentiable.swift */; };
-		2328D1D8D060309CD48C30DF2C08D254 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */; };
-		233AB756F67ABBD886C54BF9F12403DF /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941977223A9A0B4DF269C119C4BFDF1C /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		2357EB01C617A8A015615080DBB012D6 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93329935943431AA1091E935BAD68EF6 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		243C146D0E37AD7157F75B21F0D42FFF /* PlannedDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974B5B86B45250B3A6D781BD18FD421C /* PlannedDraft.swift */; };
-		24D44C09E8193C89FBA84B9B6324B529 /* PopulatedRelays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F7B317972059C369AFE5379DFDB5A3 /* PopulatedRelays.swift */; };
-		251802FBCBFF8E19829ED48F7C87F98E /* BindableCollectionCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF99BE5AAAFF13F299321082FDA0EB0 /* BindableCollectionCellView.swift */; };
-		2750688C04D696A233087DFE2A35EEB4 /* ConstraintBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F4AF68756B46ADEA118A4A0259FFE3 /* ConstraintBuilder.swift */; };
-		288478ADA82D893B93DB611328AD0CE3 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D36A7DA4746275C769F85C62F1C1C18 /* Dictionary+Extensions.swift */; };
-		289B613DD13E58EA28C0DFAF4358BA68 /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6F758F7E96FEB297B9B1029DDCF00E /* ElementsEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		28D6E884D7AB6CF2B4BFF328D2537D22 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EC1F735EA930A87CFC5B6B223688F /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		28E25C3F4B449C1D64BB8F9370CB75AD /* NBSMockedApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = AFF49DF38AA0802F8827B1691C87D4AF /* NBSMockedApplication.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2934CE1FFD51012B6875D9DF5E1D8C01 /* PrettyDynamicTypeSyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8894E94E09A813B56AAF7F9A0408DB61 /* PrettyDynamicTypeSyntax.swift */; };
-		2975A09730FD83DC0897129A11EA6585 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E31FEE7CFC8305CDDFB9951256A420 /* SwiftSupport.swift */; };
-		2A4503826B8E43663C8982C8337DCAA1 /* ObservableBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AA1B343A02AE3F34FDD51FCFA8E697 /* ObservableBlock.swift */; };
-		2A6DBF437130D200091AACBE3FBAC4F1 /* BindableCollection+TextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1476E7577E62B4414BF94FBDD6317E72 /* BindableCollection+TextInput.swift */; };
-		2B0C2A3699767FF9D7298156897939B0 /* DiffableDataSources-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 866D90BA278E42189EEDB2D2FBB39964 /* DiffableDataSources-dummy.m */; };
-		2B88C28DD20CBFA7B3AEB21A365197FE /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = CBA89870AA9EAE8927914B63A7CA1C79 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2BF384A4B734049BE048B3B602A11261 /* Clavier-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4535E8162B56FA4819A46D4475072AEE /* Clavier-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C85A44748A3F58CE8C0AE291B9EDDFB /* QCKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0A4E88409BA10522587F165FA92820 /* QCKConfiguration.swift */; };
-		2CB61F6FA511CAACB43A50DC3A82E0DD /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = DD11EE05746340EA381D5D32DB6D96CB /* UIImage+Snapshot.m */; };
-		2D153A86E8DE1CDC3F8BA50C198145B6 /* HaveValidSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25ED72AD9B3A49B0A2F044BD6A42AAC1 /* HaveValidSnapshot.swift */; };
-		2D6DB63EBCA201CFABA3012CD1C360BD /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C115EB68A03F4967063DB33A5A50AC /* ExampleGroup.swift */; };
-		2DA1A22BA212AB23D226858CE8A81D4E /* DiffableDataSources-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FA619C6BFEE11975D4BD6CA70F7623E /* DiffableDataSources-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		13C32177B632C72E7503BB78AB9A48D2 /* ImposerCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BA8A8AAC1064893E2A83902BBDDD54 /* ImposerCompat.swift */; };
+		144BD31F10D9048902D4128F8021E619 /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3BA0BCB0DE172930CBEF888CFF73EB /* ArraySection.swift */; };
+		154A42D3BBF847E3C2C7A6BB4EFAEE84 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BAEB3413ACCE398AB1857021DD512 /* DSL.swift */; };
+		182CD8F73127C0B81CF3FDD877D7260F /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E969AB5B1BAA38DC9DDCC42393F1B3B7 /* DifferentiableSection.swift */; };
+		18A00DD98F06B4C8532DA6428CDA5E11 /* Pair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF8BFBA4E507571D049BE7F9A610726 /* Pair.swift */; };
+		18C2744F13C3BF9010948AED6A237C62 /* iOSSnapshotTestCase-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F462465104147BB4A144BC12AB4056D5 /* iOSSnapshotTestCase-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18EE64773F8221084D41B48EC8E414F3 /* UniversalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077606C1F799C94688BF86BDBDDE1FD2 /* UniversalError.swift */; };
+		19A2BC7DB952645642890240B65A0FD8 /* HaveValidDynamicTypeSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5035C15F1998776D6A7BF4CCE12BC7B9 /* HaveValidDynamicTypeSnapshot.swift */; };
+		19A8009537BCAD56435B2DDC620B29AA /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 3252F8377525A241629864B054BBAF82 /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B5648DECACC2C478440DD19516ADCC5 /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C18842FCD6A73C7B087A5A9C434C5A2 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		1BFDB5EF3383E66385A818B5DF61E45C /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EC6212B74498ECCFB32485DC8F995E /* Observable.swift */; };
+		1C42ED675A4658A6DB2FAC15BD30BE3C /* NSLayoutDimension+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28343404E01E6903FA61C3346662FEE1 /* NSLayoutDimension+Extensions.swift */; };
+		1C469C17A0E35E4508F74FEB1EDA586C /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 42A166E4F28EE1901F0E1F1E24FB54ED /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		1D6A75C401E567E3620D3A3D768C55C2 /* DiffableDataSources-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F82CC7A3FFC71B7A0F1166DAFA6EA23 /* DiffableDataSources-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1DE7B12D8CA0BED403F6B3ECA871A15E /* AxisAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8869248C4992F8BE4A115183C02FDC34 /* AxisAnchorRelation.swift */; };
+		1F84FE646CD1D7BAFFB58C243277AFF8 /* FBSnapshotTestCase-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D1971CB2689FE21A1FF0F6ABED696EEE /* FBSnapshotTestCase-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		207866DD86EDE603026D5AEDAF5ABE44 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 72E0049ED94E764B84FAEF0115C91084 /* QuickConfiguration.m */; };
+		21F3408E9BD0BE7C7A9FFBF43B4F28A0 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 061F90FFFFE37ACD40F5493C435EF4BB /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2223D9864ED3F01713DA2180EF7190B9 /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5836EA5E75BBBC12707CDB1CFD6A93 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		233AB756F67ABBD886C54BF9F12403DF /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF48F49DD204444B1019B81C975C2EE /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		2357EB01C617A8A015615080DBB012D6 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689EA5A8322AEB80986A7F134CDC2EC2 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		23619A507CEFFAF261379931CD7F0517 /* Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBD5BBF10AE1CB5C4FF0C39AE105A1E /* Builder.swift */; };
+		24301FEE7601CD2C0AFC4778010D985E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
+		24B50887629B644EF820CA9E03D7F6B5 /* DimensionAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2D13FB9F1CF20CAE868B0FEDF63123 /* DimensionAnchor.swift */; };
+		288478ADA82D893B93DB611328AD0CE3 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B6C590BDD4780009EAA6D9DA337FDE /* Dictionary+Extensions.swift */; };
+		289B613DD13E58EA28C0DFAF4358BA68 /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05AB360292FB0C7E7FE977451943CF0 /* ElementsEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		28D6E884D7AB6CF2B4BFF328D2537D22 /* SatisfyAllOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375E45F8DE598CC763884C1B61C38C19 /* SatisfyAllOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		28E25C3F4B449C1D64BB8F9370CB75AD /* NBSMockedApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E54AF4ABCCADB83C4BA93AEDB2A2D32 /* NBSMockedApplication.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2934CE1FFD51012B6875D9DF5E1D8C01 /* PrettyDynamicTypeSyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07F54E35250ED85E929AC5EFAE40F44 /* PrettyDynamicTypeSyntax.swift */; };
+		2975A09730FD83DC0897129A11EA6585 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFED2A450807A45060E592F222CF4FD5 /* SwiftSupport.swift */; };
+		29B542FF55AA63058F239214171AE713 /* PopulatedRelays.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CF1B093537F4DBAFF5A7D31F69C209 /* PopulatedRelays.swift */; };
+		2B88C28DD20CBFA7B3AEB21A365197FE /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = 234C2930B6808EBED2EDB3A11CA43505 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C85A44748A3F58CE8C0AE291B9EDDFB /* QCKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AEB7CF644CB3D46AAA0A444C99495D /* QCKConfiguration.swift */; };
+		2CB61F6FA511CAACB43A50DC3A82E0DD /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B3F5A8D3916FED03F96F0EA8A36DE /* UIImage+Snapshot.m */; };
+		2D153A86E8DE1CDC3F8BA50C198145B6 /* HaveValidSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3399C4F6C2473DF25DE82F2EC6CFAF41 /* HaveValidSnapshot.swift */; };
+		2D6DB63EBCA201CFABA3012CD1C360BD /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F886AB1120AD45B880AD54B91DD455 /* ExampleGroup.swift */; };
 		2ECCAC52EF4C74E1032E0BC646BBE5B9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		301A4F6E11CFCA852B5DBAF0769DD349 /* LayoutDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6CF17F617DC7102A35F55E3C0E42CC /* LayoutDraft.swift */; };
-		30D475DF57C0C682A723231E7BCA0D14 /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 2116703722EDA0171F5C208173B70691 /* FBSnapshotTestCasePlatform.m */; };
+		30CD82097176B9713870C3A544F0DEE0 /* Pharos-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 007FEAF3D19E5FEF79EF3B667F04CD9B /* Pharos-dummy.m */; };
+		30D475DF57C0C682A723231E7BCA0D14 /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 50E6CB9489E0FD254CEA852EE8A7CD35 /* FBSnapshotTestCasePlatform.m */; };
+		30F1B9F4DEE2C6014EF6AE2F538B2E62 /* AnchorPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B32C665DB63D5618BEA62D30CBBA8E9 /* AnchorPair.swift */; };
 		3251AAAAE9DFAC0B15A8051BAF740DDC /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */; };
-		325E8EB1150189107142C7CCD0F109E6 /* SizeAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CB24D864E2B9EDE7065C65EB77765F /* SizeAnchorRelation.swift */; };
-		32995147DC30DF5022DD66C0470BFDE9 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = FF7F6290AF422BA8B8735CE1A1E8EDB2 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		329FA1BC76AC7F220BC4F2845DD6C38D /* QuadAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2525105B63E6CD74069B8CCCA3E85372 /* QuadAnchor.swift */; };
-		33E0E20B386F39CB7C5FBAB29195F6F6 /* Builder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6888AAD71BBDE61BFD3AAF42213C1F /* Builder-dummy.m */; };
-		3453A78A439D141CA39F1B769A211061 /* Nimble-Snapshots-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 124233F04C4A8ED9D924A69B7661ED74 /* Nimble-Snapshots-dummy.m */; };
-		35C095305E5FB8CF40BB6C6A7F02E678 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615BC8C141C6F89AE0566E05E73B9E55 /* ErrorUtility.swift */; };
-		35DB46D40C883E325C68BF634B42A56A /* BindableCollection+UIStepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB0BF618D589C9E452FBDD4532270B8 /* BindableCollection+UIStepper.swift */; };
-		373413256658309F9053CE22BF62077E /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A6B75F02C88D51A4CA04DFD44923FB5 /* UIImage+Snapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		37CE2F3601D1DB9908A1E3DB64A47256 /* IdentifiedAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5185DD992ED573D51556BF905AEB90 /* IdentifiedAnchorRelation.swift */; };
-		3923CDBA58AF0065A7C314BA72962B60 /* ResolverFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D9AE56C626B883BDA291D632DE065 /* ResolverFunction.swift */; };
-		3A15A6908C04BD6CC3A6F025E215A092 /* Nimble_Snapshots.h in Headers */ = {isa = PBXBuildFile; fileRef = 47E2C2FEFF5FB3BDF0F73F62177FF04A /* Nimble_Snapshots.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3ABDA920FDD838A534E55347FF35ACCC /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AF9646DD8EF00609F884B5D0709DB8 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3B59EB43186F324A79D05C3201369283 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E9FDD46562F9F6E3E7DA96E32D29012 /* QuickSpecBase.m */; };
-		3B5E796F1BFBB87AAB31305D6FCE160E /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A2BA47B3F570286E6CEF6D0A4EAD3068 /* Nimble-dummy.m */; };
+		32995147DC30DF5022DD66C0470BFDE9 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = F309142BD044D3A3EB694AE997AD8D54 /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3453A78A439D141CA39F1B769A211061 /* Nimble-Snapshots-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E83BC7353540CCD32305C6D5C33455 /* Nimble-Snapshots-dummy.m */; };
+		34B6CB00174B5F13C908CCF6B278573A /* Subject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EAB420B92C4CADBDD8BFBACDC83EF5 /* Subject.swift */; };
+		359AC5C2066CF16D461B990E82720673 /* PairAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883A0229A960E1F7517BE56CCFFE0E3B /* PairAnchor.swift */; };
+		35C095305E5FB8CF40BB6C6A7F02E678 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD450F904AA2B25734A4684283C2031B /* ErrorUtility.swift */; };
+		373413256658309F9053CE22BF62077E /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 35DD4433D51ABF748525CAE034B6AF2E /* UIImage+Snapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3780CBA3F5B178B95A9845539332C2D0 /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = C2798D37C3B7A9B9B72904ECECBADCAE /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3923CDBA58AF0065A7C314BA72962B60 /* ResolverFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC08D7E26C1209B407C76A391724D1D9 /* ResolverFunction.swift */; };
+		3A15A6908C04BD6CC3A6F025E215A092 /* Nimble_Snapshots.h in Headers */ = {isa = PBXBuildFile; fileRef = FA194F10DB279BD3B8900C5EB29D3C57 /* Nimble_Snapshots.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3ABDA920FDD838A534E55347FF35ACCC /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F405A3F6D012E6C95F68E02361A857F3 /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		3B59EB43186F324A79D05C3201369283 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = FE992045BC959155A2E98F8F50E08AE4 /* QuickSpecBase.m */; };
+		3B5E796F1BFBB87AAB31305D6FCE160E /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AEF87C07788E7106769ED61D4BACBE86 /* Nimble-dummy.m */; };
 		3B77D36A904BE2628D5882F07545CF01 /* TypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED64C613828C3F89B4683946C466B2E /* TypeAliases.swift */; };
-		3CFE6D672FEFBE8A9D10D5723FB88BF2 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A598FAB911A90E8FE58B78A829ECDE /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3E1105B44CCBDA9EC8C6C96EACCCC28F /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA1545D363F12D38D1BD95005098390 /* Behavior.swift */; };
-		3E97A584E7FDD55A6AC072DB23043FCC /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7D4F7D0291544CE5655A2EBA52B655 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		3EF19F07A10AD7D832BF2C4CE38FA8A4 /* BindableCollection+UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0602AEAB65BA2C712609045B5AF61512 /* BindableCollection+UIImageView.swift */; };
-		3FA8E6AEBD8687BF75B467C33ADF0045 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2105906B93F65A2F49738C2F73D344 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		403F30ECDF126A9FB4B80E9FA6D75C4D /* Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6345CAC4261F3B0CCC919B0A608CC2E /* Changes.swift */; };
-		40D9B846E5A8AF781C0A0C41FED0E0F8 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B4ACC27BC777A02CF3E46AA2ECD3AE /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		4174582421A9C36BF50FD0C92CD1FC2D /* Chary-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A02B633731AF54640C496A77E303336A /* Chary-dummy.m */; };
-		41CF42B7D076E0946208103109E70265 /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = A490B2F62EC1971152B2AF116E684140 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		42BC3C3CBE7E5484F09BAD3204DE521D /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD598A36158E3DB804D282D879DDBDA0 /* NSBundle+CurrentTestBundle.swift */; };
-		441BD552180843727513C0704248F69D /* ViewPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B34C0DDAE8494B195F94D39B690D727 /* ViewPlan.swift */; };
-		45C4D589AC10B11BDDDB3D935833037C /* UniversalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14896559753F34301A2D6B7932C2968 /* UniversalError.swift */; };
-		45F6E5C9DC63E19597D2132DF77B8752 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C22125074FB5EA22E43C2569D5D6780 /* UIView+Extensions.swift */; };
-		475D873E7CBDDC3BF8F87A6295236106 /* BindableCollection+UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E029DF35EBE516108FDF15D219ECFD9F /* BindableCollection+UIControl.swift */; };
-		47A3F0948E65C7F3EB2329D18B0E8AB5 /* SafeAreaKeyboardLayoutGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2114A1DC41AF49A90D10FD82496E21F /* SafeAreaKeyboardLayoutGuide.swift */; };
+		3BEC17D28DE464767FD605261CED6DE7 /* LayoutAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA8297BEC6EF6CDD2277BD12B197448 /* LayoutAnchor.swift */; };
+		3CF2B5F6A0F69AA4FD40999F1113AB7E /* SnapshotStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46599AE5A0C611FC09CF8438660458D /* SnapshotStructure.swift */; };
+		3CFE6D672FEFBE8A9D10D5723FB88BF2 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632A143858BE02B2BE015727F857E8BB /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		3E1105B44CCBDA9EC8C6C96EACCCC28F /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862B7E338C8F5ED7AE930AAA01E7A87E /* Behavior.swift */; };
+		3E8191CDB404F83CA9E632BF03A1E69F /* NSLayoutConstraint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09755CE44B8C954939385A3A1DD4C771 /* NSLayoutConstraint+Extensions.swift */; };
+		3E97A584E7FDD55A6AC072DB23043FCC /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A615C5E78ECA75FC96B04D80CDABAA /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		3F21CA906942CD3CCD81D62B1EE8B2D4 /* Draftsman-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 966C737E4D26410BBC1A6CAE82B3A4D9 /* Draftsman-dummy.m */; };
+		3FA8E6AEBD8687BF75B467C33ADF0045 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACB45BF5DE830982F05C2CDDF953780 /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		40CF0BA448F272D85CF1D2EA6F9A9AC5 /* DifferenceKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0698F24649790E50269FB7B7F9E9D775 /* DifferenceKit-dummy.m */; };
+		40D9B846E5A8AF781C0A0C41FED0E0F8 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4FDA7E7C2D315873F35637ACF652BF /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		42B1A1351CC667E3987738DE8E6550C0 /* Builder-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D347FF5DDE93935EB0D9AC2A16B1FD25 /* Builder-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		42BC3C3CBE7E5484F09BAD3204DE521D /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2055F787F1ED2C488492A76AC2ED170 /* NSBundle+CurrentTestBundle.swift */; };
+		432D9032806A77F1A1D9BC343A92462B /* PairAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42D68D42B8EE5678A3B39A958F654E9 /* PairAnchorRelation.swift */; };
+		4392AC861BB01B91B9C9D041E411387B /* HashableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771BA57969418A28D008EA70AC1428AE /* HashableExtension.swift */; };
+		460CD2831FAD3951E7F0044754D59BEF /* BaseProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40276C1791F702619BC497A310435C5 /* BaseProtocols.swift */; };
+		46DC7749C1A96AE7405F7E59F6A2E290 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
 		4836D7C1C3D6F107C083DADC2EC458EF /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CDA004F5DCA53CEA3A5163B7D49A7B /* Section.swift */; };
-		4892D1670C7EB6A1DC6EDECCBCEF4E06 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5871F2D8BD5FA7A8F36D8D1E00C3919 /* DispatchQueue+Extensions.swift */; };
-		498D0CEF04FDF36BE2B89A67015FF3A0 /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E4AA269DA9667341CBE3776BECBE92 /* String+C99ExtendedIdentifier.swift */; };
-		4A457767C9968D139BD8AAD877DFC117 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F237A74B8BB1E27B08E12C2BDA9B2E /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		4B989B9468131355311F2C783C63F62B /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037DB31BFFE1BEB2B9B63504EEF695EE /* StagedChangeset.swift */; };
-		4BDE92D9BF98E825391034D6C58D2727 /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE8561F30C072431561A4DCB25891B1 /* ArraySection.swift */; };
-		4D5B4BF9DCF45EA57142E7CF80487F6E /* BindableCollection+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF97B906871DDA288C4841F5BC888DE /* BindableCollection+UICollectionView.swift */; };
-		4DB106EF5D81F121EA58D82401C5DD1C /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDBDF140EC034E0BAD97E6742F33BC9 /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		4DFD4AE1B1C12F59014A9C1FE8F7AE47 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DF8EC9C18CFF1F4E4ED4E9EC4B6624 /* BeResult.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		4EC19A4F9EE9863B3CF7BDB7607FE96B /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC3AD31675EC3ED4DA43C1F45048076 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		4F175C4035DA2C1897D706C6CDC06674 /* iOSSnapshotTestCase-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D0AE7FB63803E68997653B97A558AC58 /* iOSSnapshotTestCase-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4FA57A8866F7E4556059CBF2CACA6C47 /* Draftsman-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BD32D66C8033157D927794F2158927BC /* Draftsman-dummy.m */; };
-		50FE064E2BB5709AED743A914E0859AA /* TypeHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7EDFC4395005DE3CFC31334A4AB40D /* TypeHashable.swift */; };
-		51BAE003E7BD972B4F6EB54CFB7E1BF0 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B57DA84B91C4D2D992EF3C79B08A93 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		5200969A3EA2CE2B88A9DEC371BAA107 /* ModuleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3486F5ED3D237FD3828F0EF25E658696 /* ModuleProvider.swift */; };
-		5258586AADBC8482EFAFB4B591A17E03 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491828D6127E09592D5F8141593540C2 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		52835799BC977EF3785C1E2ADA594566 /* Pair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467664C80243597EA4403F1CB2686513 /* Pair.swift */; };
-		544525E7AB35880EE5B156B7359766D5 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 264507D64793B8AA56330BA7CD8BB6B8 /* QuartzCore.framework */; };
-		5448447D317610CE0DF66B87CF6F1094 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9286E4E70459FF4031B156D5D2F4D858 /* Closures.swift */; };
-		5558B876B579BC1E79BD3D2B19148329 /* UIApplication+StrictKeyWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B4C315FAA47AD6C9BC4481F16C11390 /* UIApplication+StrictKeyWindow.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		58853A4B2909E54FFAAD0F763B294E85 /* Chary-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F26A592169A3D35FB26EBA578DBB0198 /* Chary-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58CAB839E63D7D4575D3DEDF8C98EDD9 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5C7D0634FEC0A3A4B7737E0C93F71E /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		59E889166FED63A0186ED35B67459977 /* Retainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B76772AB1A7281813E7595D579C25F2 /* Retainer.swift */; };
+		498D0CEF04FDF36BE2B89A67015FF3A0 /* String+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19564BE517BD21456F219972F53F8CE7 /* String+C99ExtendedIdentifier.swift */; };
+		4A425006F878F1CBC0F424626C9AA3FF /* PairConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2966097444B6FDBDAB00AE88274B640 /* PairConstant.swift */; };
+		4A457767C9968D139BD8AAD877DFC117 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6369A57BB4DF6BA0969372DC56D987B4 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		4A564DACDC390C751499369E6FF5B4EA /* MappedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195F5B9E6987992261A5644E7AB5A7E5 /* MappedObservable.swift */; };
+		4A895A0E79B49EF205F51F80842AA1E6 /* ConstraintBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A3A9585BA13997F71FD9AD9D380431 /* ConstraintBuilder.swift */; };
+		4DB106EF5D81F121EA58D82401C5DD1C /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C9558AFDB71D8F3CE7422A01AC428A /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		4DFD4AE1B1C12F59014A9C1FE8F7AE47 /* BeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8FA4E0DFD336AB01E9201A729A56095 /* BeResult.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		4E459BC27812C8290FEB7BF262EEE5B0 /* TableViewDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0427D7265C12F833F973F27314FAD4A /* TableViewDiffableDataSource.swift */; };
+		4EC19A4F9EE9863B3CF7BDB7607FE96B /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE54E2C190061D03BECB93BB05655AB3 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		50FE064E2BB5709AED743A914E0859AA /* TypeHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB124C4D47C4B109D574BA2CCBF3657F /* TypeHashable.swift */; };
+		51BAE003E7BD972B4F6EB54CFB7E1BF0 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C04209E3093D861761CD3BCE9259C1 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		5200969A3EA2CE2B88A9DEC371BAA107 /* ModuleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57947969E6D853BA69C70D02F764123B /* ModuleProvider.swift */; };
+		5258586AADBC8482EFAFB4B591A17E03 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F79D8669C7DADB8D9B17B0206628CCA /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		525A1C2A851EF4B3F28EC1C2956E6EDB /* MainThreadSerialDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839651B9A3ED124E05D79285E1342857 /* MainThreadSerialDispatcher.swift */; };
+		5448447D317610CE0DF66B87CF6F1094 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF61774000E7A82647EA088F8534FE8C /* Closures.swift */; };
+		5472E78AC4F7CB1F9187A98FAAAC3E92 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D7AFC5E1DB6380FD96D386996C7522 /* Array+Extensions.swift */; };
+		554BB1A940C8663FBEDE2424F0468379 /* LayoutPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 421F80C00CEFC13B1384C59BBD8A2E49 /* LayoutPlan.swift */; };
+		5558B876B579BC1E79BD3D2B19148329 /* UIApplication+StrictKeyWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5C64EC41ADFD2C50C433A33EBF7B13 /* UIApplication+StrictKeyWindow.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		55CC56FE56AB92DE8C0A3A459238E1C1 /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04548115C406B5083D2C4EF6AED037BF /* UIKitExtension.swift */; };
+		57804A62E51146B84086A85A386C15BE /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */; };
+		58B4642071DA0F1D03C35022AE6FAD8D /* SizeAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4868EF6D73C9BECA98DE6E7824EF7F70 /* SizeAnchorRelation.swift */; };
+		58CAB839E63D7D4575D3DEDF8C98EDD9 /* Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D9073747974921B39E2860CB14DA4A /* Await.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		5A75DFB9C9F5856F139AE4367BBEEADE /* Pods-Artisan_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E4D0590D7EBC02F63139D10864C42A74 /* Pods-Artisan_Tests-dummy.m */; };
-		5BE525FF6FA14B999ED2CCC0AA4FA0CF /* FBSnapshotTestCase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 116919CED1B53F03220C837A941F0125 /* FBSnapshotTestCase-dummy.m */; };
-		5DE534ADC468F5FFC43371CE7138923F /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE5F2D356B1DC3B2AAEAB6F9501BF22 /* URL+FileName.swift */; };
-		5E168B898CA8FBB501E7D51F996BD11D /* BindableCollection+UISwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA07CF6F10CF589A79C080EF0A97BA3 /* BindableCollection+UISwitch.swift */; };
-		5F44D028B5746976D2EC4A15D2ADA8EF /* Nimble-Snapshots-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F53C998FB56DF28EC9D4E0228A4C06 /* Nimble-Snapshots-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5A7CE55AB8400FD6DF4E54196DDF32D5 /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F69A269AC77D3F59D202D2142035811 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5BE525FF6FA14B999ED2CCC0AA4FA0CF /* FBSnapshotTestCase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CD86455E3384C9970EA0E4997A45A3B0 /* FBSnapshotTestCase-dummy.m */; };
+		5DE534ADC468F5FFC43371CE7138923F /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073843B45712907BA4EB44E78ECE5D9B /* URL+FileName.swift */; };
+		5F44D028B5746976D2EC4A15D2ADA8EF /* Nimble-Snapshots-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D0A251C16525E043B5843A049F091676 /* Nimble-Snapshots-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5FBD95B0688D536E680201096933003B /* PlanComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE9E9D3B34CE0AC817D6BDF956C2532 /* PlanComponent.swift */; };
 		604A73AD1D0E82356F2A073C53BC6517 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		6089C2C3F28210D73F3A78EFD949EC92 /* PlanComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4004351F331CDA599C0EE531AE4354E8 /* PlanComponent.swift */; };
-		60A059AA3734D5D3F2F73D07C427F4C1 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = D4A68C7DF5D05CE684BAA1B3B6C7B982 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		612581CCD8346C696A80E6BC09D24C1F /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 213376EA86515B5196B6CEDB20D9339F /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		613B317E1F2C2044C30389A46CFB2034 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		61AADBA10A8CDEF7242F1E9D3DF77D72 /* ObjectRetainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF36F5D0CE99E6FC7261A5575530B30 /* ObjectRetainer.swift */; };
-		61EABFAB466BF8A6A1402694240846AA /* AnchorPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F3898660B738CA03CDED30F94DD96A1 /* AnchorPair.swift */; };
-		61F1ADB6BE662783C1A01C2C1720A9BE /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AA40EE0532F8F52AD329802954B1F9 /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		6267F8BDBC4D546E1BD96E7C942C7881 /* Trio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0AC4EEB7D237989BF921F123FA80B6 /* Trio.swift */; };
-		636FE4C69452530C06EFA0A21FB6BB2E /* LayoutDraftBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B058E81936E33FC8F7675DA75E30323B /* LayoutDraftBuilder.swift */; };
-		63F06E97C680EB6DDB8D395CF72413F6 /* PairConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB90DAEB2EAB5974F43734AF4AA73E8B /* PairConstant.swift */; };
-		640CCE9C3A28AA3CA15510899F9140EE /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = DABDA0FD6F2E305012326F8CEE10D76A /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		64A3CBD089502CA3829F5A00101CD1BF /* SnapshotStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F678919E0FAD0B365E60F42B0CD2307 /* SnapshotStructure.swift */; };
-		6504CEE9820D6B9BB796825506EAA66A /* Dimension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E6797C9FFB372179EB33EA9F090E97 /* Dimension.swift */; };
-		654580360E6694D7F7CE85CE5390DA79 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E5C7A9F4E5987055BB4C5220CC1F0 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		6587CA6D9AF4A71B10F3DCED7BEB3C6B /* UIKit+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC492BC359B3FBBB1C4C190B284F8FE0 /* UIKit+Extensions.swift */; };
-		67F1963AA7C9EDB78127AD5F566A4949 /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = 596B36A1643F56BF912E08FF0BD7616F /* UIImage+Diff.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		682E769B8238493BCCE5CFDDBA1B5199 /* SingleAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEAC6C2E9E92E355963AD626F25304F5 /* SingleAnchorRelation.swift */; };
-		6875FFF2CF40CD67ECAE212EB9E746F1 /* PropertyWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E8621C5B92ACE1CFE113E2F824881E /* PropertyWrapper.swift */; };
-		68F639E7D3E58E1F5AE984E6D7832B3C /* DimensionAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363DE00C624F3969A50A8CEF6082D4D6 /* DimensionAnchorRelation.swift */; };
-		6A47C53473FBCF2FF5C85069FBD4CA8D /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA253C6F893C7247603F0FCD2CE3586 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6AC16BD6F1261A4D9ECE473A8D144944 /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D8166F31C51BE7D7D67BEAFC4D20A0 /* Single.swift */; };
+		60A059AA3734D5D3F2F73D07C427F4C1 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D46B055BA3B982118DA31D58B699444 /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60B38B554815AB4437F16414573E0BCE /* BindableCollection+TextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496C445CE5F70C0D6255CE0989598E46 /* BindableCollection+TextInput.swift */; };
+		612581CCD8346C696A80E6BC09D24C1F /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = FB82ECD0B5EFF8BFB731AAB2886E6BD6 /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61F1ADB6BE662783C1A01C2C1720A9BE /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5B452DFE64C3F186B6A229EC15B95A /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		640CCE9C3A28AA3CA15510899F9140EE /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = CB97CEF87923E8ACD3BCCFE9CC952D2B /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		654580360E6694D7F7CE85CE5390DA79 /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AEA58696DE01ED099AE800C305E423 /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		67F1963AA7C9EDB78127AD5F566A4949 /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = B510E77FFC87218687B479FD7EB92A97 /* UIImage+Diff.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6875FFF2CF40CD67ECAE212EB9E746F1 /* PropertyWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E793A0179FC848D812A8C566E36B99 /* PropertyWrapper.swift */; };
+		6A47C53473FBCF2FF5C85069FBD4CA8D /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AC131BCEA2B6B7F4927EB980C0283274 /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6AED7F323A6E3EA02AE5A29EF248380A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		6B32882C4FE34D76A85C2B90EE61EC95 /* TriConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A12240624413AA73C433E2C28AC1C5 /* TriConstant.swift */; };
-		6C1386A39405BDA544D5BEE2C9155AB1 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0E17F6121AD73BA387D5ECC1267DB6 /* QuickSpec.m */; };
-		6D2F9F1DC6C1DE1C73F4382904B9C97C /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8499B9BA02D1623600AEAC915BDAF /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		6DB21625B845EE64783C837C0E4C2705 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = E9E8062690C092BDCDE2886F0200656A /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6F4F5989C108EB29AB735E9CAF4B6E0A /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94973BE36813745D40773DEF1E94862 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		6F796B7E3AA428C9D8E88F0F2269664F /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFD3CCCCE07CE0D1393442A2D71CC3F /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		6C1386A39405BDA544D5BEE2C9155AB1 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B53FDCB52425FA777C6A028903B7A93 /* QuickSpec.m */; };
+		6C78BC97577569F36E3AA230AE569E42 /* DifferenceKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C06E3445C4F18D29E68F5DFF3CCF9F1 /* DifferenceKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6CA34960CAE04CCD19B6B554D71F5420 /* IdentifiedAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C78966D39E8E662EDE0E59F01DBFC43 /* IdentifiedAnchorRelation.swift */; };
+		6CB291A7D2B6B89CCBB0CD5601415E84 /* Quad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177D1E3CC6CE47EED4125A8CCA49A4A9 /* Quad.swift */; };
+		6D102298B810A01E5BC7448146CE189A /* Dimension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB08AC89A4D792FE11A42B075CCB7B02 /* Dimension.swift */; };
+		6D2F9F1DC6C1DE1C73F4382904B9C97C /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532A0F77815F32D8E92CAF614C7F79DD /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		6E12F9555DEFB926B1F939FCCEB42732 /* SizeAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA0D995518747C79A23B7B4B85A43F4 /* SizeAnchor.swift */; };
+		6F4F5989C108EB29AB735E9CAF4B6E0A /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6395A7FC62F1F43D388A1E50BEC558 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		6F6ADDC5A714E78254EAB328A4724451 /* DiffableDataSourceCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BEFEEF45D922E53EC7E9A20A2A7432 /* DiffableDataSourceCore.swift */; };
+		6F796B7E3AA428C9D8E88F0F2269664F /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E4A020A29A84C2D3F5D020D8F912C3 /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		70294D4E92BB86B1854EFAC3471525CD /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = D7BDCDB2DEA5D5770412DD6711C714CE /* UIImage+Diff.m */; };
 		703055175C0D2FB889792EB4B0865384 /* Pods-Artisan_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B8710B35A5A37D4372FABE6653537450 /* Pods-Artisan_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		707245706183C9814604FBE34CD83152 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C69B45238F09C84A73D8FA656194E1 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		7190961540266108624E854866842A81 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 929DC0A856CC06157FC87654231ADBCE /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		73878610E166B2B725F49B6F0D1BEBBB /* SizeAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2156F5872120D784B153AB8C85D2E9E /* SizeAnchor.swift */; };
-		741D1D02CBFC1C77EC53BC83C7640A73 /* ImposeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5E9E3B03D1A8AAA9222E50F3F5C893 /* ImposeError.swift */; };
-		74339C58AC4E5631FB8C0E662668A796 /* UIApplication+StrictKeyWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 014DF8974B85AB955C8A9EE26F71ACF8 /* UIApplication+StrictKeyWindow.m */; };
-		7454FD321C71CA670B04FE091D02B0EC /* PropertyAssigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6D2F146291D9143E041E631C67E3DB /* PropertyAssigner.swift */; };
-		7548DED50FECD1FD601FAF972B194B31 /* NBSMockedApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = C5C7F9616050C2986E479A4B1D24AD07 /* NBSMockedApplication.m */; };
+		707245706183C9814604FBE34CD83152 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EEA129A74B9B8ADC38251EA4409F55E /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		70DA6795B83DA31D18B2F3D5965503A7 /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6115345D980F0556C6332245CA345F5A /* AnyDifferentiable.swift */; };
+		7190961540266108624E854866842A81 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FC519DC81C6962CCA4FDA122C485942 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		733A21E4CE69B14047D8F387D69FAB54 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = AE5F81D6211CA97CC73304A3C24B3CFD /* FBSnapshotTestCase.m */; };
+		73717E7331080AC4B3E3110DE952E691 /* SingleAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44AE95E5F5D1D0E395A6DBDCACAEFA2F /* SingleAnchor.swift */; };
+		741D1D02CBFC1C77EC53BC83C7640A73 /* ImposeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B552FC5FE0C95E8C842ECA0E352547E2 /* ImposeError.swift */; };
+		74339C58AC4E5631FB8C0E662668A796 /* UIApplication+StrictKeyWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A21DD4FFD20C66A685AE00C08503232 /* UIApplication+StrictKeyWindow.m */; };
+		74DBF3C235FEE288BC54C5ABF4BCEAEA /* TriConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE502FA68628C7C40494651F4E477BC9 /* TriConstant.swift */; };
+		7548DED50FECD1FD601FAF972B194B31 /* NBSMockedApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 27837971E417F85EB03E879791E6F54B /* NBSMockedApplication.m */; };
 		75D720009920B474A72D70CBCB086FEF /* ScrollableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2775B18D8D33776758AEDE3238E651D0 /* ScrollableStackView.swift */; };
+		75FCBB886383B54128A1F595133F0B55 /* ConstraintBuilderRootRecoverable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6572DD077B69C33A0869ADB1F914861F /* ConstraintBuilderRootRecoverable.swift */; };
+		7740B6375C07754804CC3102DEEFCD93 /* Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA902042566B507F124F51C452215E5 /* Publisher.swift */; };
+		77615F639C9073C5DBFEA9DA7E4F4FE5 /* Observed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BB44E8E1EC29EBAC3D595062201982 /* Observed.swift */; };
 		78EC57A801E9670D8CC987112B60DF9F /* CellCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A31266FFC30884F7B03B9F82C33DA3B /* CellCompatible.swift */; };
 		794C927A15C31A2CC45F9ECF7D512AF4 /* Artisan-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 39180F6DE6BDAEB8B3D4BEDEA81031A2 /* Artisan-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79A9ADCAE72B5F30CE882F79CDDDD47F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		7A1BA2D46C33A517B95B684EB3EF1E05 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AE0350F61BF5BCAE1037D76874C50A /* Array+Extensions.swift */; };
-		7A3D50E092FA279DD673AE2320A34466 /* Enumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E87CDA7581F7F55BF08764F6EC8ED4C /* Enumeration.swift */; };
+		7A1AA2790BA2E012212CF1B917980E3B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
 		7ABD47CB30D3EE057F74DD0B89D00EC6 /* StackBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7C46E2D61F96106CF4CDEDC0C6D4D8 /* StackBuilder.swift */; };
-		7C67CBD15D9B5D0B7769B2F469478332 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E1FBC050FF9EC462546E7C5E4DBFA5 /* FBSnapshotTestCase.m */; };
-		7DF5C2582E1C9DE5BC6BF84C0AF1337B /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C321D660A3A039C92AFF5EC6568C84A4 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		7E6C9773E4826E2412FED678E1D8E36E /* CollectionViewDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD93D2494BDC47F3D6375B3627185B4 /* CollectionViewDiffableDataSource.swift */; };
-		7F19181825D8609EF99067ABDE505064 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6843374F3B004144301DCBA87669EFC6 /* Observable.swift */; };
+		7C0B227AC201698361889409EB2E91F8 /* PlanContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E197AE0F4FD3E9A3C44B1AF8AE1FC3 /* PlanContext.swift */; };
+		7C67CBD15D9B5D0B7769B2F469478332 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F6108F0CE795ECABEBD357F00D4C740 /* FBSnapshotTestCase.m */; };
+		7CD218BEF1035FF32D3346415447874C /* BindableCollectionCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE5CB2B34860BC739B5B3E30676774A /* BindableCollectionCellView.swift */; };
+		7DF5C2582E1C9DE5BC6BF84C0AF1337B /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82534E64080EFDF31CE186AC81026BFB /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		7E45FB66ECBA8FF80335F6EC6D1ED5D0 /* PropertyAssigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D29A2980DF760562AF1E27A12D163A5 /* PropertyAssigner.swift */; };
 		7F5D0D3F6CC5E09BD0DB9518F8F10474 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		80428B0834B1272AB4E96E00D3FAA081 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D543A275A56B9790A70AB7F4B8F0D17 /* Example.swift */; };
-		808BFDDC9CE4DAE92E67299DB188C50B /* Buildable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE04C7FB4214A8F79CAA22CE977D225B /* Buildable.swift */; };
-		80C9C88FCA3879858AFD900FFB77A4FC /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CC20F83553359B1C0A2A26F3882F67 /* Algorithm.swift */; };
-		80DB7C67B0D7A32BF885B5CD17C745A1 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12AD0ADA33523EEB4893EDD223B91C33 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		8316A6E428239F2AD1C11964366B5668 /* TableViewDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E95839933806B8921D5C8DE28F6C0 /* TableViewDiffableDataSource.swift */; };
+		80428B0834B1272AB4E96E00D3FAA081 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F38BE71F309685F2FBB4E97C07762CA /* Example.swift */; };
+		80DB7C67B0D7A32BF885B5CD17C745A1 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E24FE81A643C5BF30D89D91A5A16CB9 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		81806735586A6390F80A9B0AB5E71354 /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = F541104E82B4BE54EE77FE77A2BA07EB /* StagedChangeset.swift */; };
+		82AAFF3107CB22DCD981D8A53C908667 /* Draftsman-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 57751974DD2DA624E2A6EF34F6CC73D1 /* Draftsman-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		831C50E61E435828A085DCC5C2308F51 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
 		834427F7251B74CED28B89AAB677699D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		83E1A8E0E496C1F3D8129FC4412E32BE /* PairAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F831D762664684524DA3F196496B5F1 /* PairAnchorRelation.swift */; };
-		84E944E5A0E6DF9CA19CEF6CDE604F99 /* Planned.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE68D6488A4E79BA69B9BC1CC29096F /* Planned.swift */; };
-		86037D5CAD49EC09A2B944ADBF561059 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19543F9F650566C4F4987E4E42013C21 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		86F84DE049A0E2CADAC8344E20D070BE /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = E5C23D4845530804A03AF0BFC7F3470B /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		870D61DCD277FD0F0A90F4A712841A9C /* DimensionAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BAA31AC885F0732D60994336F6A1B6C /* DimensionAnchor.swift */; };
-		87535E5C51E9F6B7B1517FEA95033D1C /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7FDCE302C82F7EC931F92909B1002E /* QuickConfiguration.swift */; };
+		843E75198F6DD8D9B06EEED71D507EF5 /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 282764781C059B0DB57FDACA0C0BB60B /* UIImage+Compare.m */; };
+		848AB53029C3B830B88054CCA1246E0B /* BindableCollection+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBE19E94D69FE1BBD172BB9A5515781 /* BindableCollection+UICollectionView.swift */; };
+		852F00B5A1E9B85302C8EBF6A4C1B3AE /* Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1EDAAA84402FD96B5DFCD097F99F7F /* Changes.swift */; };
+		8571797ED9A7144EDC496ABD61FF0A79 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
+		8601CB49410FE95D7B2C69717273B66B /* Enumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A2F81F85C9B07EECF3F60C28D3A732 /* Enumeration.swift */; };
+		86037D5CAD49EC09A2B944ADBF561059 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD03B9F6E829B557161728E1637C345E /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		864CEFBA058BD399B9EAFF9A9E84757C /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = CB52DE9A16B2B47581B7590E64B8F1D4 /* UIImage+Snapshot.m */; };
+		86F84DE049A0E2CADAC8344E20D070BE /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = B10869DBD981C089A89A6A64FE9BFE3C /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		87535E5C51E9F6B7B1517FEA95033D1C /* QuickConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140062391D682A565AD648026E4E457D /* QuickConfiguration.swift */; };
 		875A310EAF4D0C136C3FFFF5E0335BE4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
-		88380C6AB029E423E69827B204BFF18A /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0EE6D378EE9C97DCFE4E72C8B21079 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		88380C6AB029E423E69827B204BFF18A /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ADFD21EDD7BC59AA71C74FA1EC65EE5 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		8847CB9E0ACE43510603B324C078E749 /* ViewBindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204A70EA8EF89FDDB7814F9642AC1AD0 /* ViewBindable.swift */; };
-		884B940C394CD879E18805B55EFF7181 /* Pharos-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EEF34D60DBF7221FF5C141271DD5E23 /* Pharos-dummy.m */; };
-		88D2A17E09B7AE99854037B566CC7BB3 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8D6B4BB1FC7844650895AFA34C70C /* Dictionary+Extensions.swift */; };
-		897F59AC1D7E12F4BFB70FC683E6E4E1 /* MappedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013F337C417F599D11D7E1AA46A57DED /* MappedObservable.swift */; };
+		88D5B1AF0B26880CA3208CA7B4DAD7C7 /* ObjectRetainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C357CC4F83E907EBC7C57371695010 /* ObjectRetainer.swift */; };
+		88E10D0804EC18528E1BB24196179261 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
+		89005B1F94507D14AC56F261650F92D4 /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 319F4E219DF8828E32FA4DAE77D513A6 /* UIImage+Compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8984658E81D88C409A99362B5230A28F /* Pods-Artisan_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D6A9245482A20D3BAF9295BDDCF22B /* Pods-Artisan_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A34B01AD3EC82C1DC4402C75551689C /* TriAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7547B7B3C8005E3B8079DC61E0651AAE /* TriAnchor.swift */; };
-		8A9C3526F42D9E4E1F9C36B8D967CFC9 /* XCTestObservationCenter+CurrentTestCaseTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 31B8A16F787055DA4E2AA900A60FE4E9 /* XCTestObservationCenter+CurrentTestCaseTracker.m */; };
-		8A9FE00A3D26CFEDEF3503C93FEFC954 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35AE296C3182345CEC928D48A23B1840 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		8AE19756F0126FE92AF625E36F3D70FE /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 151419F1D17BB2AFBE291BE6603281DD /* UIImage+Compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8B0078AB8490C1ABA17ACC8FE35649A1 /* TriAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC34CB5D7D09A959721C4D66E80F1C0 /* TriAnchorRelation.swift */; };
-		8B292CA1D45D17B845601AFD526A1185 /* Impose-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A9A41D5250027CDBEBCB776BA9E40264 /* Impose-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A9C3526F42D9E4E1F9C36B8D967CFC9 /* XCTestObservationCenter+CurrentTestCaseTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = D5AE692E2EB0B0AEFEAAED8B489EA021 /* XCTestObservationCenter+CurrentTestCaseTracker.m */; };
+		8A9FE00A3D26CFEDEF3503C93FEFC954 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA150DEC94AA33CE21F364C2F0148673 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		8AE19756F0126FE92AF625E36F3D70FE /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 184DAF9B26959C4D115DAF1C9B9D0AF7 /* UIImage+Compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8B14D1B69B8B1DE7D4128ABEB134FCE4 /* MulticastObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D95A3739747F6D8E5F08B964B1A5CE1 /* MulticastObservable.swift */; };
+		8B292CA1D45D17B845601AFD526A1185 /* Impose-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F5FCA74EC5519B8C0B122E0EFA9C4AA8 /* Impose-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B5D405F5E3D42100667427387BBD3CC /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4FFDEE39A327160E6D951BFB3C7BDD0 /* Array+Extensions.swift */; };
-		8C95DB320ACF935831507B6E5EAAB701 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		8C98E99A78C8A1005E9E5C6AD0E5D411 /* FilteredObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DDE4C1C61A71B532678AF658A1DF0B /* FilteredObservable.swift */; };
-		8CE12EB0301C60FD5519BCD9430DE549 /* Draftsman-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 824E2426D17BA9CB5A3CD3DF7A6337D8 /* Draftsman-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8EFA132322053E7D8A1F9F380B5D8935 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246BBB114D597989D3FD6CBF785BD540 /* SuiteHooks.swift */; };
-		8EFBBB05612F069AE61988C9DF400CC4 /* NSLayoutConstraint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8C98C269A257389AB4C6E0E29D5221 /* NSLayoutConstraint+Extensions.swift */; };
-		8F5593DFFFCAC3D618365EC2590A3E31 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFABBF7638B2D98E38AF38BA19C7D4E /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		8FDAB5CEFE8D633BC1E41423FF377BDF /* RootObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A621B1EEB47FDD39E44D89BBFD664B /* RootObservable.swift */; };
-		9196F8ECAC419357914F0A9BAC241A0A /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3AFC1B1E1786D2FB423F613E03C250 /* Extensions.swift */; };
-		91E226CE9A95EF5443941448BC1E23AF /* DifferenceKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FE22E1954325C34D83FEAB162FACF4F1 /* DifferenceKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		927137AD29366E6595BB3F728EF8D842 /* DiffableDataSourceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338DCF99BBA3285919D0EF8C6E24E157 /* DiffableDataSourceSnapshot.swift */; };
-		92DE6AC67462F0A507D3187892D4FA8A /* Equal+Tuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD901917E019C8ABD4A7789A1CF13F4 /* Equal+Tuple.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		8BC3A9F393884AEC5B7825B5C46C69BC /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72359285018337286FC39596CA366C49 /* ElementPath.swift */; };
+		8BDFE8C686050C072A847E3C8B13F166 /* BindableCollection+UISlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6174C9B77403AE99CA3044A42A8EC81 /* BindableCollection+UISlider.swift */; };
+		8D2E9B44D15CEE6A15F834C4E4A16D8A /* UIControl+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FE248E6C827424F70FCA7E36086ECA /* UIControl+Extensions.swift */; };
+		8D3449D41FF1CF0042903A3ED8565628 /* SafeAreaKeyboardLayoutGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B97A754B428D562946AFADB43864D /* SafeAreaKeyboardLayoutGuide.swift */; };
+		8EB44BAB71A05ED880217F649FD0BEE5 /* BindableCollection+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17DCC147768DED6F51EC2B5D62D195E /* BindableCollection+UIView.swift */; };
+		8EED37A7EB1696E084D4740EDDA2CE7C /* Chary-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 092B025FA20152BF9A091DDA80929378 /* Chary-dummy.m */; };
+		8EFA132322053E7D8A1F9F380B5D8935 /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C02A346FD15D3F5476714B23F5171D1 /* SuiteHooks.swift */; };
+		8F5593DFFFCAC3D618365EC2590A3E31 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63FD177C37DDAFDC697F400A9310B45 /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		8F60FF351D49CE3A778EC1129AD74F1D /* AxisAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BBB227EDBB7BFA05AC77D1BABA6987 /* AxisAnchor.swift */; };
+		906295CBBED92366E30F037D23100B79 /* ViewPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7629630622DA71E4B7D0AFD598B206 /* ViewPlan.swift */; };
+		91D87C64BA4676AC1FC34F2B6985925D /* Buildable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4702B8DD851EAA0D60C2C6A2A8EC6 /* Buildable.swift */; };
+		92325E9EFA8C4AF3D9BFF001DC4CDE1B /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 4262D15483B148E863D8AD635B8248B3 /* FBSnapshotTestCasePlatform.m */; };
+		92DE6AC67462F0A507D3187892D4FA8A /* Equal+Tuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1073257FF467D61B3567391C3347261B /* Equal+Tuple.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		93EBD157714466DBCA14EC4E6B3C5283 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
 		941D1C303D02387E179719EEFAFCC7EE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
 		94F80BACDABCD406BB067B2C02AD8215 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A321BFA6052FE6B5BD5AB4570F4063E /* ViewModel.swift */; };
-		981F6B1579CE5D0BDB6E936DFC0B24F1 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E93D1ECF93B321BD6EBA755387AB13 /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		993ED0D1D74DDFAF99D4108636EFFA64 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0403B771FD9C4E62D1CB303801A276 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		994DAB83E925F5BF28B00DFD0F9795CB /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 707153269BF13501493C162D115689EF /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		999DA39565C49BBEC6656C2F10BE7B81 /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24855FF78369168A881DFF7C4D8694A /* UIKitExtension.swift */; };
-		9AB3D03BC12D48113C0AFB7E687A274D /* BeginWithPrefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18E47C3136CAA8450CF75B91D1BF625 /* BeginWithPrefix.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		9B297E4BEF3DD9716B7916ED923A3A83 /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0782B8A6426FCB4AB4091CB666D25E91 /* DifferentiableSection.swift */; };
-		9B4B84C8A58733E87C1F30CDE34F3BEE /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E0A5C89B7E50AA6958466482117588 /* Filter.swift */; };
-		9B5BFD0363B5596EE8EE2D2E2998F527 /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA7CFBA8461236442A0AF5BBE8436CE /* Changeset.swift */; };
-		9B981E6DB0846F597838D6995E3F2EAC /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B98B8CBA5CFF46374EC365AEC200506 /* QuickSelectedTestSuiteBuilder.swift */; };
-		9C75931ADE8431B4C3C4AE2D59E70977 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C4EA59F720E9CD8FA617D9D0353564 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		9CD73EE4AC05F963C515EE10F85CF4F7 /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = CDB0343BE61468CA36A4E2E5B95B018C /* FBSnapshotTestCasePlatform.m */; };
+		95598D3EFFF16EB12C3F9E1AAFF12DC2 /* BindableCollection+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EC89C31D92EBD7585C66594467491C /* BindableCollection+UILabel.swift */; };
+		96C8BA2F79B77CDEDB71F166FAEF53D7 /* DiffableDataSourceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4648DBA99775EDEE965856D13AE52A8 /* DiffableDataSourceSnapshot.swift */; };
+		9769029E1F88EC467172B799326B4F8E /* Pharos-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 541FA35F2A62EF0A9C0304AD7C4CC98C /* Pharos-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		97A5E63764F3624560F77789BD078F7B /* LayoutDraftBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCAF70F682FDCBD18B53CD120AE86CB /* LayoutDraftBuilder.swift */; };
+		981F6B1579CE5D0BDB6E936DFC0B24F1 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87B24A186FCDB02CF0D595F18D832BC /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		98453F902536AE57C2E9F394882022AA /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = D4557AA2B890C3D688C60A4F36B1A2F8 /* FBSnapshotTestController.m */; };
+		993ED0D1D74DDFAF99D4108636EFFA64 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77A21B9AA97E3109FA1008506D1ABBB /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		994DAB83E925F5BF28B00DFD0F9795CB /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AC7A401831533E22D2F837FEEA21494 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		9950DE894F23901DEDA58F1FD683148A /* BindableCollection+UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC0EC031A806026B8DBD5036426CCF4 /* BindableCollection+UITableView.swift */; };
+		9AB3D03BC12D48113C0AFB7E687A274D /* BeginWithPrefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AAA70E12E4023B8070CB7B61B0CA10 /* BeginWithPrefix.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		9B4B84C8A58733E87C1F30CDE34F3BEE /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359E7CCA46718B35B888F399B903A4B9 /* Filter.swift */; };
+		9B981E6DB0846F597838D6995E3F2EAC /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A422D5BB4C544536C7365E1DB3870D85 /* QuickSelectedTestSuiteBuilder.swift */; };
+		9BECF91A2508A3C77D5E1D1B32FF37C6 /* RelayInvoker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9A656426259B3441D2BA08A88EF2AE /* RelayInvoker.swift */; };
+		9C75931ADE8431B4C3C4AE2D59E70977 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2394AADAC17794D0E0F44BE7A3AC9152 /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		9D3C5E2F56838937146191468A893244 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */; };
-		9E403C2191B0BC0D93607EAA5A769CDB /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DBC7CBDA5471F0BE50D3622F7D5EAF /* Atomic.swift */; };
-		A00D39F03D611AE6713E836F6ABD7B0C /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CEFB7928E2BE82AFA4DEC9A9952D72 /* Differentiable.swift */; };
-		A017E1A4E1C0AA61CDB6F1E8382D3384 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B940F31E7DCE39678C3E125F3A69A0 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		A098E1AD51852CF09DE1C80A6B58A352 /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 50A9942D2C54ACE9FD03CC16950143E5 /* UIImage+Snapshot.m */; };
-		A0F1DDBCD61B35967DED6A8F6A69B9A5 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86F8711879153EC95FB09F62D41F0DF /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		A10190A4FEA7E53D9F66560A0A156103 /* LayoutPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F3063851CB50979EFE5A7D230758BA /* LayoutPlan.swift */; };
-		A22A14D9C81B4C430D17B7953B603A87 /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CECF18F545C9F447A05B0E382C439F /* ContentIdentifiable.swift */; };
-		A2878723A641DFD73FADC2DDEB3BF6F6 /* Injector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F338F1E4E9E61ABB15C513F6AC4B772A /* Injector.swift */; };
-		A327A211C8B71069F32FAE5F5B3807C4 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA6812B2408C6D670466B1A95C65396 /* HooksPhase.swift */; };
-		A357C8E38B58FA37B8E1A6103D4E9A0A /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E15091123661BA326ADCE65EEF5C381 /* XCTestSuite+QuickTestSuiteBuilder.m */; };
-		A487451E3CC40D7F9549FA292435273B /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = E1C2655283A979119409EFA45B5BA703 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		A65EF5C093AFD2F3D84FA1A6A7EBD81A /* XCTestObservationCenter+CurrentTestCaseTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 940091854BAF3314743B88BD11043B89 /* XCTestObservationCenter+CurrentTestCaseTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A74AF435538B54124BA7644830495E51 /* BindableCollection+UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AD8F885C2D2573BE89E22A8E0944B7 /* BindableCollection+UITableView.swift */; };
-		A7B8523A43C3DE4FFEBC4165C2FB0291 /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 637217F02BB06F450F12E4594C1BB921 /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA02A5A85750ADAFA89A47E566582EA8 /* DifferenceKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DD5047B5EE6841E39808E4DFCFF3921 /* DifferenceKit-dummy.m */; };
-		AC0278DBE6921D2AA8CA82CBE8805202 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208AFDC82EE25E28BDCC9EDB19CFF78C /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		AC1B0A94D98FF6A485E56165BDAAFB8F /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = A251B732798AFC40B71AC9CFFF9C2EEF /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		ACAA345A1CCAFA1F4EE69B3C25D62558 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAEEA9C8039CC76007D04EF53BCFC43E /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		AD022386EA01CE480072E4C2E261BEC6 /* QuickTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DBF26FBAC36C1B04011AFE2E072C52 /* QuickTestObservation.swift */; };
-		ADD1923D18914005102FA3D9D9B778A5 /* StackCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC878C53567060ED9A38659A3C83CC7 /* StackCompatible.swift */; };
-		ADDD4335306146E17016DFAC6A14760E /* BindableCollection+UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92433D9F3EF6CCA6F3069239BFDCE84C /* BindableCollection+UIStackView.swift */; };
-		AF56411683F8BEFA2F1022B6AE755C00 /* AxisAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B008CAA163FB6520E7093797421AFB23 /* AxisAnchor.swift */; };
-		AFB4F603FD0F5C407CB8920F6A5BA7A1 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF3A019400B5734A24B45703228637B /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		AFBE2FD05E98C4D0967FA59E975A1CA9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		B1239F7A587246442BB5544BA980D77A /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DA37CEA2CFF8889284A1DA7C81F838 /* FBSnapshotTestController.m */; };
-		B24A21FA385D27663802BB59FB33F503 /* Pharos-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 04CD123B00C52F5985BDFFF81F339DD1 /* Pharos-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B52281F9F4340D4FC8ABB2FEB1FEC08E /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = BA17DF457CFBD231322647992FBA2C23 /* UIImage+Compare.m */; };
+		9D57386585F1A5A7E7ED0300A5B33ABC /* BuilderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CADB8F3B95641242DC1BBD53A279FD /* BuilderConfig.swift */; };
+		9F01C8CA09B0513BDEA092A94AA92A3A /* DiffableDataSources-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 20576AE59007C9DF9C9F9C11A85EAE24 /* DiffableDataSources-dummy.m */; };
+		9FCF4616FCE54CD76D49EF0722DA5A8F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
+		A017E1A4E1C0AA61CDB6F1E8382D3384 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79CD87051B354E1AA997F90BEEE728E4 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		A0559DC11F6F122B11E16BE791349E67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
+		A0F1DDBCD61B35967DED6A8F6A69B9A5 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0251F36EC4506C3F07058D0347A9C0 /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		A15702D3B339BECA866626848EB824FF /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040865FA34F88378DC68B67D4B6F39B1 /* Single.swift */; };
+		A279B8C38B36F85C8880488B6129598F /* ClavierLayoutGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB672C174FDDB9C34E15D27F97579B1 /* ClavierLayoutGuide.swift */; };
+		A2878723A641DFD73FADC2DDEB3BF6F6 /* Injector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080AA22494874DC9D005B3FEAE1C6894 /* Injector.swift */; };
+		A327A211C8B71069F32FAE5F5B3807C4 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138CE0A74585D52955307BF289A4535F /* HooksPhase.swift */; };
+		A357C8E38B58FA37B8E1A6103D4E9A0A /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A20FA603F61E844FADA7E97683CA5E17 /* XCTestSuite+QuickTestSuiteBuilder.m */; };
+		A37BFEAF0C23EFB8860E24D4E12E5C0E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B620BE5D0A41075A55ACD16A85699D /* Extensions.swift */; };
+		A487451E3CC40D7F9549FA292435273B /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = A9BE7F0C1BCB6D0C892EE6AB25A63660 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		A50DCD5438C4D60DE8C788ADD3070083 /* BindableCollection+UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF77DF15101029DD52CA5FB1BBB233F /* BindableCollection+UIControl.swift */; };
+		A5C635FAFD5C43B769C0C09B00203355 /* PrioritizedAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4220988B6F1501CF122C8127F73416 /* PrioritizedAnchorRelation.swift */; };
+		A5F8D976790F9A67FFD6BB4C4EC5C788 /* BindableKVOObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BFBFB8102BC67FCF7EEE9B108A70FB6 /* BindableKVOObservable.swift */; };
+		A65EF5C093AFD2F3D84FA1A6A7EBD81A /* XCTestObservationCenter+CurrentTestCaseTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = DB4AFA40F5765F599F01498E9CB7A35C /* XCTestObservationCenter+CurrentTestCaseTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA2E4FAA4AD39139F3E5B386F7D6AAE5 /* QuadAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73655E683AB52450A1CA90262E8A05CD /* QuadAnchorRelation.swift */; };
+		AC0278DBE6921D2AA8CA82CBE8805202 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AC65036D6E9A84860DDA4629635668 /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		AC1B0A94D98FF6A485E56165BDAAFB8F /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84001CBA62A9367004CD433B640DD2C /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		ACA4D897EA1620347797A65EC3D479B8 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 264507D64793B8AA56330BA7CD8BB6B8 /* QuartzCore.framework */; };
+		ACAA345A1CCAFA1F4EE69B3C25D62558 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB4B50F8B3B44F718F04C4767E2AA13 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		AD022386EA01CE480072E4C2E261BEC6 /* QuickTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8362060E458F5BFC4BDF7249605B707 /* QuickTestObservation.swift */; };
+		AD177D4187066B142ADF73539CB87EBC /* BindableCollection+UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF71DB9FC15504A681CDE32E585F700 /* BindableCollection+UIStackView.swift */; };
+		AE9C841FA505A53F5C2B51568C857C8C /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = 558025F2AF4CCA6D7D76F2E9708B695B /* UIImage+Diff.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AEDE03FD8D62B73E4001FF88024E22A1 /* Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FF02CC4458AFD25F8A0B0713C6F14C /* Axis.swift */; };
+		AFB4F603FD0F5C407CB8920F6A5BA7A1 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9140C28C0126C157068F8AA51BCBFFBD /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		B21FE4D322BC5A8FFB55009063F84AA7 /* LayoutAxisAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA849E7083368971A58B897F06ECF4FB /* LayoutAxisAnchor.swift */; };
+		B2365E1737EB50769635809045365AA8 /* Trio.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B6A6775A20D152B793ABE6068A8011 /* Trio.swift */; };
+		B26FC252B21E5DEE689E9A2ABE6D8105 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC20B956EC210DAB2CF6F8199575A6E6 /* Atomic.swift */; };
+		B42224836402409706B58CF13972FDF5 /* PlannedDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59850663F6808953A081C401EE7FC99 /* PlannedDraft.swift */; };
+		B52281F9F4340D4FC8ABB2FEB1FEC08E /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DA30B0E36FABF4B4BEE94393F7CEFB9 /* UIImage+Compare.m */; };
+		B6AA8499F16DB05B80ED3614EAE80E67 /* UIControlSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A7BCB53C87F305F3ECBAF24B5C860A /* UIControlSubject.swift */; };
+		B6DEB7E9EE7C7E6661E33C3A24E125DA /* BindableCollection+UIStepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C1AA4976F684F9222D4FCC6D92820A /* BindableCollection+UIStepper.swift */; };
+		B80E43938DD8C4D02E1ED4C2C06D7E91 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31086BA04FDF4933C31013C7FC9EC2B /* Dictionary+Extensions.swift */; };
 		B935D1BF9D084C2D7D66855128B0644E /* CellBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451067079A0D0784EBB644C73B45F577 /* CellBuilder.swift */; };
-		B93F3526A95D7F43EEBFEE5E453E4795 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361ED4D2FF4042A8D5CE4E45FC756370 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		BAAF54567B513199C31BBCB2CACF639B /* Observed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BEC56B47AF0597C3979BD00CC0348ED /* Observed.swift */; };
-		BD3ABAC28025564DCF2E6C12009435DF /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 13A26E597F85833A5DBEB72D41506ABF /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		B93F3526A95D7F43EEBFEE5E453E4795 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EEC9238191C52E8003E1A80A8FE63 /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		BA02AB6527987BC123E5FD1B1136DDE0 /* LayoutWithAnchors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D561B067E876E7BE7C6A544A3D2873DB /* LayoutWithAnchors.swift */; };
+		BBA2E6EB286FD3D00055AE11 /* ViewBindable+Retaining.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA2E6EA286FD3D00055AE11 /* ViewBindable+Retaining.swift */; };
+		BBF057DC2871C66F00D34444 /* Observable+Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF057DB2871C66F00D34444 /* Observable+Binding.swift */; };
+		BCF3FA1B96CEF82C24894BF3C97C50D7 /* ViewPlanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BB5A352F71AA65CF099E08BE7E4A8E /* ViewPlanBuilder.swift */; };
+		BD3ABAC28025564DCF2E6C12009435DF /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 50FBBA947BEE1065C7BE95C98378F011 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		BD602583D077852FCA7918CC484E533C /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69604901D33E9B6FA694B0F51C0E928 /* UIView+Extensions.swift */; };
-		BD7AB6BB94E45794A06B8481C87F62FF /* BindableCollection+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9940116E1153DACAD38FA9A34C30A9 /* BindableCollection+UILabel.swift */; };
-		BE5C9102A453B7EABB6718AB18A48A8C /* Mirror+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6927E9BF13E65861749978D859C967E2 /* Mirror+Extensions.swift */; };
-		BF62525E5628A9F7604BA8479691318C /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC71B5B5F7E28282392D4AB25855397 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		C03116C765F1A8893559730965ECBAD8 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EC2C6761019AFE9AA0076456D8E101B3 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C20BFECB0A04FE439AE243D89E687B8A /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B6D072DB73E3F7D011511BE01FD688 /* QuickTestSuite.swift */; };
-		C390C6005353FB986CB52F474CEF8588 /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1349149C334A58270EE0D3DE80512ADF /* FBSnapshotTestController.m */; };
-		C5DF891232B50DB810099403734CFCEE /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB6C7B5066447F0A7DA7B5429D95B08 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		C60295908A3575FFE203D484560325B7 /* MulticastObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B11432EA47C88167C2BA72B5E702DF4 /* MulticastObservable.swift */; };
+		BE03E1824820C073442D86968791D2F3 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A93A1036ED2EC26102002AFAED3A135 /* SwiftSupport.swift */; };
+		BE5C9102A453B7EABB6718AB18A48A8C /* Mirror+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE95321F63A2E957E29B7045E2FADC /* Mirror+Extensions.swift */; };
+		BF62525E5628A9F7604BA8479691318C /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9195138B9659C5A257AB4C60A9C1352 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		C03116C765F1A8893559730965ECBAD8 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE05D6CB733F1E9FF92736AC05AAC74 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C20BFECB0A04FE439AE243D89E687B8A /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B534E42655245FAB9C69A4487F1065C /* QuickTestSuite.swift */; };
+		C38E10DE4C9CC4EEDB7732A8A1FB6C3D /* DimensionAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC23AE382126E4156635A2A5203DEF4 /* DimensionAnchorRelation.swift */; };
+		C390C6005353FB986CB52F474CEF8588 /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D98D74A637620C3F25F0B45F1D33A60 /* FBSnapshotTestController.m */; };
+		C4E944A897A01FAB13D82934AC075A57 /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F1765C8C3C2398470CECF4BF768BBF3 /* UIImage+Snapshot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C5DF891232B50DB810099403734CFCEE /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FD94A9BB3F36AB27646DE937182371 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		C70B22B92E2E7F7C1FA5F6CF52B162FA /* ArrayBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1FD9458005F1B0A61C10F6F295E60E /* ArrayBuilder.swift */; };
-		C751EB8C93C32D7CF4E12379099DD367 /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0B3185C60C16AE6AF792939B09586B /* ElementPath.swift */; };
-		C7DB9FB7C8378ADC0DBC744F9359C0C9 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B446FD412422B0711C9D35FE6CDE3F8B /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		C7ED909C9C7C014A513A6D3DCC86CD08 /* BuilderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7984627147E649F201C684CB5CDCFFA /* BuilderConfig.swift */; };
-		C8174F5A3EB38338601284181DF5F0A5 /* BindableKVOObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB8F4FD65984DA69BB3B7FA10CECF21 /* BindableKVOObservable.swift */; };
-		C8539F1BDF052B57BDB129D3D4B07364 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4B3143E105F6047E8E8377A2E8F225 /* Callsite.swift */; };
-		C85E1092F4DAACDD63FB8E8B0E144095 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704F2C4AFEE84BF6378E879AF0E10205 /* ExampleMetadata.swift */; };
-		C96B370E9B3442878448F8FFFDC98C7A /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FDF15EEAAB47AC41015F3959F43DAF18 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C989A20A8867701030281222989034E0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
+		C7DB9FB7C8378ADC0DBC744F9359C0C9 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31AEA7BA2234939049F20CB527268B2 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		C8539F1BDF052B57BDB129D3D4B07364 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69874B3F269F3E5EF41C576485A481B7 /* Callsite.swift */; };
+		C85E1092F4DAACDD63FB8E8B0E144095 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4AD0DD2AA7544F961631D73670F17D /* ExampleMetadata.swift */; };
+		C96B370E9B3442878448F8FFFDC98C7A /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 738DB8348A74CF2E7BBADC057CEE838B /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9EF5171D780B4A37745A9842FCFDEDF /* UIKit+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ED5ED8415D32B291E1BC644D71952E /* UIKit+Extensions.swift */; };
 		C9F76407497DF0205D7460B36D22259F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 264507D64793B8AA56330BA7CD8BB6B8 /* QuartzCore.framework */; };
-		CA14590491F62205BCAD8DE14A419F52 /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764FD06EF0185123816A74099FA09DCF /* ContentEquatable.swift */; };
-		CA32F74C00C2448397720AB161360835 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FC627095A5289654BCD5EDB3344A8 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		CA54C09A12400567AFFCB407EEB7E154 /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = FF239F2678DC67F57B9EFE59DF6CA32B /* UIImage+Diff.m */; };
-		CBB74DBB6BCD31B34EA1D86B3D23D23D /* Quad.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E7D3B6A6164ACEA24310ED4E59FC4C /* Quad.swift */; };
-		CD4958E799D5C476B461FC9C11C05439 /* PairAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887317B216A4BCCE5DD7F88F40D95831 /* PairAnchor.swift */; };
-		CEA5CD204F0121C01E2ABFD7D23F85D8 /* InstanceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAD8FFF3C02E9634A79DBC9F07FE8C1 /* InstanceResolver.swift */; };
-		D0DF6D2313FF6A9BE8B31FD49E7790CA /* SingleAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E26B8E68FAB43946B433FDE9715CAD /* SingleAnchor.swift */; };
-		D2C0CC317B1575A23F5659E8FC126A66 /* ViewPlanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D1F4421650691693EEE9DCE38DF9B8 /* ViewPlanBuilder.swift */; };
+		CA32F74C00C2448397720AB161360835 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C17DC79943927CE4CB57CEAFEC047 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		CA54C09A12400567AFFCB407EEB7E154 /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 135204924EA6DD3EDDB271B47C115EBD /* UIImage+Diff.m */; };
+		CA760EB69F42BAB61FB19657EE7F8F38 /* BindableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382A55601270B70E371C84D180E3DD79 /* BindableObservable.swift */; };
+		CD0BFFE37E2073445EF530778DACF2F9 /* Clavier-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E767CD536D9E2EDF469D1D30C0116D22 /* Clavier-dummy.m */; };
+		CEA5CD204F0121C01E2ABFD7D23F85D8 /* InstanceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16DA6F75AD70A35F08DEE2351413D20 /* InstanceResolver.swift */; };
+		CEBC83DD97A53E72395D7F85D09EFDE6 /* SingleAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77127953399AB2C7DA555E1F602A82E0 /* SingleAnchorRelation.swift */; };
+		D2771D0749EE458B3702825DEF1D5B59 /* Retainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6229B0CD8E96ED8F76C41BFA7BAE3F /* Retainer.swift */; };
+		D34F3FCC98BD7511A24FDA022387E6AE /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF5C2ABFBE30CA66E8118A7D53882D8 /* Algorithm.swift */; };
+		D3A93F2A905D5166ED4E22A75212598A /* BindableCollection+UISwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63773A0754DDFB345DDB4958B2171E8A /* BindableCollection+UISwitch.swift */; };
+		D4B7DC65E1C2CDA3457D008345ECF750 /* LayoutDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2D2533E4A629D636BF9B8287DC344C /* LayoutDraft.swift */; };
 		D5A20CAADB9A2172EC6F56487536E14C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
-		D683AF41DC18E879253A8305B3B6EA55 /* Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D2F5BF85464810822619F63ACF2D7 /* Builder.swift */; };
-		D6F1A9AFE522D73CB8BDF851FF6F7ACC /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7279BFE3593C038F922B8075BC930FD /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		D6F1A9AFE522D73CB8BDF851FF6F7ACC /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E88F2FC6E8CEA8850ED0C105DB2C956 /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		D81A78E76C17D08611D350CFE3608F18 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C562EEC818D23D9005E9D7208B689085 /* Cell.swift */; };
-		D8B8FCEC597824B40986C8F4F7B50899 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C82DAC0C57E365D204090849130501 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA4CF37D028D29B49C9F79076725C3F3 /* HashableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABDE83C8DF944F8AFB50BEFED09C5C9 /* HashableExtension.swift */; };
-		DA9B61878019B5428B614BDDB5948F01 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = F22AF64DC2D88452F9112FBEF6160703 /* QCKDSL.m */; };
-		DCCA75688121736202FD12E24F43C2E0 /* BindableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E562708482BF2EB6CEDE447CACD70964 /* BindableObservable.swift */; };
-		DD130331C3820B0A4A655D6422167410 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8378862E5657D3E81B13FA3E9FB998 /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		DE8992A898293C55054ECB9458DC1221 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
-		DF2B831FA4647CBF33A78A174F4C4D9A /* BindableCollection+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09FFF38275C1AF9EA37D19C8CC0F1C5 /* BindableCollection+UIScrollView.swift */; };
-		E02E2D468B5505FC0FCD7651FCE7DC44 /* Builder-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E25CA2115280857E254C83343CEF68F /* Builder-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E07D988C96A2486C54A88D458A72443F /* AxisAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9CE90FD78A4F310C33D2FBD8A69297 /* AxisAnchorRelation.swift */; };
-		E0939C4B62B7B7983A21254E1F2D776C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		E18F746F2FEEA373368ED2EEB60C3FC7 /* PharosContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFE1652DFB1A6C20E2E725000E8B0E6 /* PharosContext.swift */; };
-		E1CD0FEF6BA86FA9C28038C818E2514A /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 8605ED7B5C71FB407B2F6113BA5B6512 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8B8FCEC597824B40986C8F4F7B50899 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 33D39BB5086838B625545698C799FA66 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA1E1B261897F2AE80ECC2F98BCDA5A3 /* RootObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C90DCAD2ECBAAD0BD5AE144863BC0C /* RootObservable.swift */; };
+		DA9B61878019B5428B614BDDB5948F01 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = D0492BCE3BF1DBBEE3F866286D283E0D /* QCKDSL.m */; };
+		DBA61AA93F2DB387B4365D37DDAD7E3E /* TriAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D384368372E08215C8C7F1658F875ED /* TriAnchorRelation.swift */; };
+		DD130331C3820B0A4A655D6422167410 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537B0813DF8853E15EAB48020BC37C99 /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		DDA13E0574B6016EAFA8CE9544192619 /* ObservableBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC94E2A5AA0C6DF4F61B60F52D99318C /* ObservableBlock.swift */; };
+		DE8FE7A30841D2B565F3B1EB2EE265B9 /* Chary-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B4AD9CD203F70ACB3E195F22431ADE3E /* Chary-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFA2F427123C018E72F6C1B1158525C6 /* QuadAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989AABAEE0CC5902F8A5E26BBD7B36A7 /* QuadAnchor.swift */; };
+		E1664B9AAE9392E00711AE5B2A03B644 /* UIControlAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F09C7987A82245AC9D22FCC83983E9 /* UIControlAction.swift */; };
+		E1CD0FEF6BA86FA9C28038C818E2514A /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = 88F2B3D13A94367B19D0B7834299462C /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E25932ABB6FF30911BB1B8A89826B554 /* Artisan-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9ACAA415EAD5D6AE0A28043DECA2F /* Artisan-dummy.m */; };
-		E2D9E6C8707AF298E1B8D1C5FEF609C4 /* DiffableDataSourceCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461A6EA77ED58EF823CFB13ED29303D9 /* DiffableDataSourceCore.swift */; };
-		E2EE2E7797C383576ACBFE4986179459 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE62266F808CBFD0D6623A33DFD2A27 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2F3B26D370E3D05964FF9975F1CE2BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		E30E374509412D38745961534DE991BA /* QuadAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E45DEFD541A174D2203936603A261A /* QuadAnchorRelation.swift */; };
-		E3C91587EB8E329F11D38CAE5396C545 /* LayoutWithAnchors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BBE8B87F291B6B5267E9C7B51F55FA /* LayoutWithAnchors.swift */; };
-		E5301341D4968B1ECFC5E30007A8B504 /* BaseProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C6BB2302184FCDDD2766D6A1A9AE2C /* BaseProtocols.swift */; };
-		E5ACC239A1C2E515D4939ACECD147445 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113B2ED3110211EB9C756CA9061B3ED6 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		E7593225EDB35233DBE6ECCB98E0D75E /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFAD07ED4D9C4D337A37AD812B7192F7 /* CurrentTestCaseTracker.swift */; };
-		E7B66A171A462DEE295DCEC789B74A85 /* DynamicSizeSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5E0A775E484E6F762BDE377BE09C2D /* DynamicSizeSnapshot.swift */; };
-		E7C0C525FD3F87ABFDE7E7B30E646858 /* MainThreadSerialDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA02F9EAD65B3866B7E6D0F4B770F39F /* MainThreadSerialDispatcher.swift */; };
-		E875BEC7D7EFB87589068F4D0739BB52 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */; };
-		E8FA62A6E1AAA86361EBBF0F889DE87D /* InjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140195E1A681EB716339B07AD26AC7DF /* InjectContext.swift */; };
-		EA4EC4B3853541FDC946239C036D12C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 684B3930A71D239368783ED680809ED6 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EA66E4915561796193A53B0C84A51169 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
-		EAA0716B31E50CB0FDDFB20E2AA2B226 /* BindableCollection+UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC847D7774E3F23D2B7570E7967F34C4 /* BindableCollection+UIView.swift */; };
+		E2EE2E7797C383576ACBFE4986179459 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2842061E008A78CC6E094CB36C3E247D /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E3536FF0730B9071967A3B8353C35981 /* PharosContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BFB9FF4B3FFD029A1F6401F9840F3A /* PharosContext.swift */; };
+		E3D1A07FFEC8DD51E34B208B6A318253 /* BindableCollection+UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DDDF5B0A0F397D66D144F393A337C2 /* BindableCollection+UIScrollView.swift */; };
+		E4300F6490EC170A803AEEA8D9E55CDB /* TriAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128133987354DBF367D15981472ED297 /* TriAnchor.swift */; };
+		E44F8A3CE8B7C40AE873F890AEC6C7B4 /* Clavier-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FC626DACEF42BFBBE329407F595188A5 /* Clavier-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E5ACC239A1C2E515D4939ACECD147445 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D92F4723D78E0860F1944E726237418 /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		E7593225EDB35233DBE6ECCB98E0D75E /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8215801333035857FBFC89E285C49053 /* CurrentTestCaseTracker.swift */; };
+		E7B66A171A462DEE295DCEC789B74A85 /* DynamicSizeSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B57699296657D79CAA785094F2473FE /* DynamicSizeSnapshot.swift */; };
+		E8FA62A6E1AAA86361EBBF0F889DE87D /* InjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06165C4EC18EFE4D5624DD11EAE435 /* InjectContext.swift */; };
+		EA4EC4B3853541FDC946239C036D12C9 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 41C92E3B75B8BB489E56022BC5A65376 /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB892573E1CA332ED26DCC659406E79B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */; };
-		EC6CDB60BA96BB0ABF51ED46458F59AE /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = C61E47D6447772A0396A8C2FAEBE597C /* UIImage+Compare.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ECA174DDC97A3BEF3574FDD61B9EEDBF /* Pods-Artisan_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CCF7B3BCCB90A6C28C29ABFDEF6ED19D /* Pods-Artisan_Example-dummy.m */; };
 		ED35E8FF46DB475D049C49DB94690132 /* LayoutDraft+CellCompatible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084FFDD67F09953C61F3564D458239A4 /* LayoutDraft+CellCompatible.swift */; };
-		EF1CD2CF2E482AE911D78FE57A16E27B /* LayoutAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02F56E32697B6FE0C57E60EA9A0D058 /* LayoutAnchor.swift */; };
-		F0007F098EA99BE307A2C907017ECFEA /* Impose-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 238B3705E5F1739794C4528440C69B2C /* Impose-dummy.m */; };
-		F0199FBA4B66A724FB123BEC6B7B952F /* PrioritizedAnchorRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88A4C15CFF2BB4D4B235F25F00A4448 /* PrioritizedAnchorRelation.swift */; };
-		F03DE2B3F1169D0B71ADF9E6428595FC /* BindableCollection+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C471E1764F3776F488CC7D21C35E30E0 /* BindableCollection+UIButton.swift */; };
-		F194BAB9B258057E8246017258737BCB /* NSLayoutDimension+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AA2D74F75CB85E9BF0FD6835563CEA /* NSLayoutDimension+Extensions.swift */; };
-		F19CE6947FBCDB8A185070C7D90709AC /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBED13A3083A6AA931656CFC54ED3917 /* SwiftSupport.swift */; };
-		F1D91144B0B756BA7723E0AE68ED6605 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A76C7B0359AB60C345E0243CE8AC43 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		F3CFCCC86D9247F7261EFA3CE9483B46 /* ConstraintBuilderRootRecoverable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB6922C2FBD9852EE6A94C9D8CADA31 /* ConstraintBuilderRootRecoverable.swift */; };
-		F46E9B84622B2E579E206F844194FABC /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = DF8474C5E95F98A5EF474612071F7087 /* UIImage+Diff.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F591765960EECDBB53CB4E5329290A4B /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036911C73F6CEC1C554E5C54D1A3AC05 /* World.swift */; };
-		F5D862257F6AD6A45A2E0D2023E4B932 /* PlanContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC731D84A2034B1FA6A066DF0C92A65C /* PlanContext.swift */; };
-		F8211C89835CD4106BCC584D260CF7C8 /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379D9D9BF59BB007E1C8FC9D850B3C0B /* DispatchTimeInterval.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		F94ED0C040D8EFE1B1227A464F81E92E /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = B882EE91D19B7E057370DF90349F0D39 /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		F9A961CFA0E2BD3C6A94E282069AD80E /* BeWithin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC0B9A19C9416482F7687FE5B6F50D7 /* BeWithin.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
-		FC4F734925BC0EDDCD7C10AFBF93C576 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A14A4B7BAFF38B8A86BB376CB4A8D80 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FDE31A7670A75E62086CC6184105ED51 /* Subject.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204267D3B8FD83A3EFB617F91FC32DD /* Subject.swift */; };
-		FE67CE5AE4DFFE6B850FA43334EEBDC0 /* QuickObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A57D62C8FBDEEDBA8021BF1E4767684 /* QuickObjCRuntime.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		FEA8C3E9543FB2A316D5A8F89B13D411 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6053046482A15766D6A1C2DEF70B8A5F /* Quick-dummy.m */; };
-		FF8307B7346F4D3BA13C11AECFE6EDD0 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6D1C3C83ECEB5F19F8EBC10113DE1E /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EE7AA6A8AF5BBD680CB644244326B904 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B60884EEFBE9DC817336288FBAF5A7E /* DispatchQueue+Extensions.swift */; };
+		EEE381DB3D330E2E2A9196DDEB537E40 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = B0E51E0B834287C702C906BAD9CBE9E1 /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F0007F098EA99BE307A2C907017ECFEA /* Impose-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ED69060AD03A2693E157EAE1FE9C9FD9 /* Impose-dummy.m */; };
+		F1D91144B0B756BA7723E0AE68ED6605 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11D5FE18BA090E3D202EF3D5B43DF68 /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		F2630857708FA35B462A66E2EC6869B7 /* CollectionViewDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A148A1ED371EA196D66E562169C764D /* CollectionViewDiffableDataSource.swift */; };
+		F29E2A1D29C1D0B0375F0A28BBFBD3E9 /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9014FC05E8F6E9C0478938C470E53ED0 /* ContentIdentifiable.swift */; };
+		F3C7953A86E43277393BC8D8D65B9F95 /* AnchorExtractable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580972A7EE536DDC3991BA43667E65E /* AnchorExtractable.swift */; };
+		F473E8CED6F920C90D66718A6040697F /* FilteredObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81500AF4AFA894D9404262ACBD9274FB /* FilteredObservable.swift */; };
+		F591765960EECDBB53CB4E5329290A4B /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC1EDB602505BD76D34AE87C42765BE /* World.swift */; };
+		F8211C89835CD4106BCC584D260CF7C8 /* DispatchTimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCA813B7968AFC1A0F558B7FAA98240 /* DispatchTimeInterval.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		F94ED0C040D8EFE1B1227A464F81E92E /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD038515EE39DB69BA1B155638B8190F /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		F9A961CFA0E2BD3C6A94E282069AD80E /* BeWithin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE60D8EED0C1A735B7454F76E9F57FE0 /* BeWithin.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		FA0D61FE871DAF660589ABBC8C844037 /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780C99873DB13B4722413879850158E2 /* Differentiable.swift */; };
+		FB10DF412AFBA6C4A9A53D94B85D5D6C /* BindableCollection+UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167FC2DFEAF1BE295D182FFF693008C5 /* BindableCollection+UIImageView.swift */; };
+		FB4ED8D04439915EB30AE12C61A94866 /* Planned.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32EF1E24A7F314B050CF9DB5EEFFE62 /* Planned.swift */; };
+		FBAFD3A6BA0D1B66DAF1649F5D128D78 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */; };
+		FC4F734925BC0EDDCD7C10AFBF93C576 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = D08734FE82D4DFBBA5AE8FF59A8DAF35 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD8332F5BC06374E21CA5B030F40431A /* Builder-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C40F41CC267DEF04A76CE0C47AC8C04 /* Builder-dummy.m */; };
+		FE67CE5AE4DFFE6B850FA43334EEBDC0 /* QuickObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = D43BFE8393EFD717CB3E59EA90EAD967 /* QuickObjCRuntime.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FEA8C3E9543FB2A316D5A8F89B13D411 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B11DB1DC4C24B95BA829B2B7703289B /* Quick-dummy.m */; };
+		FF36A2447FCB9A41A540C49E872AAEF3 /* iOSSnapshotTestCase-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9333ABD679D60CE2C93C9573E586E0F2 /* iOSSnapshotTestCase-dummy.m */; };
+		FF8307B7346F4D3BA13C11AECFE6EDD0 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = E42F520E0364DEFA6D20F0D1B2139958 /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0287288EDAB12EDE41DCE9A15D774436 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 222C9BA9370230B670273F42B5E7F810;
-			remoteInfo = DiffableDataSources;
-		};
-		05CED05DF0E3231BEA9C1B0C0E90FB5D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0DED92290FC5B4F771B42870DB0A2D55;
-			remoteInfo = Pharos;
-		};
-		15EEBB0B6587881440BF4B130989656C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8FC6E51285E4FD828A61BEFD2100CD64;
-			remoteInfo = DifferenceKit;
-		};
-		2C1E7861209B7701A7342F873A7F0480 /* PBXContainerItemProxy */ = {
+		0F42D60C77065D3C2C1B9E7408C76D0A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = C393038B0BEF088C1B93E6528005862D;
 			remoteInfo = iOSSnapshotTestCase;
 		};
-		31CBC2A6B79E05C60033F01490181331 /* PBXContainerItemProxy */ = {
+		27565631321124B417A91FBE84218F0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0746DCD7C48E9F6BAB723766294323A;
+			remoteInfo = Clavier;
+		};
+		36752B5F11C87BBE88E9091B0378367D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8FC6E51285E4FD828A61BEFD2100CD64;
+			remoteInfo = DifferenceKit;
+		};
+		4421E8C02A6056CCA36CD72FAEE3CF51 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F13695E06195A78EA8A95F8C7ED0D2F;
+			remoteInfo = Nimble;
+		};
+		46F2B4762745DEB020A8267559446C4B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = EE19095A8C98E0BC5774005673495238;
 			remoteInfo = "Nimble-Snapshots";
 		};
-		3805407BF13FCA437BF46327E5860AC0 /* PBXContainerItemProxy */ = {
+		4873377312149BE354E102C915A19633 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ED7AB6873A9DA430A18E0109776D3707;
+			remoteInfo = Builder;
+		};
+		48810CF178C0F8027956FB95975DF1C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 6A3AC2D6739DCB3DEBEB81CF81B207F2;
 			remoteInfo = Draftsman;
 		};
-		44C5E4C29257D75DF99C73129D4A253E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C82891EAB7293DBEE916B21F57E8474D;
-			remoteInfo = Quick;
-		};
-		514D201F6B22558AD840030086B260F4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 6F13695E06195A78EA8A95F8C7ED0D2F;
-			remoteInfo = Nimble;
-		};
-		681720131352C45062887FF260FFE12E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 98A98149697C80CEF8D5772791E92E66;
-			remoteInfo = FBSnapshotTestCase;
-		};
-		6A86163777D8391846C16F10582A5EE4 /* PBXContainerItemProxy */ = {
+		520A3E35B1BDF1C8AB5F47EB3D1168B1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = E2D1FAC32F648BB9D26C11B8F69E8326;
 			remoteInfo = Artisan;
 		};
-		6FC24FD0A3F937F420E1A98443C58827 /* PBXContainerItemProxy */ = {
+		568CD903A5533598372D90D7361B8309 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 085BD8B607F192AF5EA09EA6EB2E7801;
-			remoteInfo = Impose;
+			remoteGlobalIDString = 98A98149697C80CEF8D5772791E92E66;
+			remoteInfo = FBSnapshotTestCase;
 		};
-		8193BCA66065396ABFDE383DD4230213 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ED7AB6873A9DA430A18E0109776D3707;
-			remoteInfo = Builder;
-		};
-		9164A560FA5927F6A315EBE6B30739AE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0DED92290FC5B4F771B42870DB0A2D55;
-			remoteInfo = Pharos;
-		};
-		9EF17C7586CC06AE22A69BA0827079D4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A0746DCD7C48E9F6BAB723766294323A;
-			remoteInfo = Clavier;
-		};
-		A573CF3FF90D9016597EC395258A8A80 /* PBXContainerItemProxy */ = {
+		7B2928FD99A06E3F1E96D406B7631FC5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = C393038B0BEF088C1B93E6528005862D;
 			remoteInfo = iOSSnapshotTestCase;
 		};
-		AE10E0E494C69F672AA2DB3736CD6F82 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 6A3AC2D6739DCB3DEBEB81CF81B207F2;
-			remoteInfo = Draftsman;
-		};
-		AE2650D4E6EFDB14BDB1F691C140ABEB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E4D0DCAA1CEF50B24DB0FE6DB58A775E;
-			remoteInfo = Chary;
-		};
-		D0D8CC918A91E9375D5C987E29E53F0A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ED7AB6873A9DA430A18E0109776D3707;
-			remoteInfo = Builder;
-		};
-		D4DC9F7EF5EAE66BBF32F924F65C7316 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A0746DCD7C48E9F6BAB723766294323A;
-			remoteInfo = Clavier;
-		};
-		D6E9860B3160EB961354B058DBED7686 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ED7AB6873A9DA430A18E0109776D3707;
-			remoteInfo = Builder;
-		};
-		D8BA7D686AF2DC6BBA10E559D4E5FDD4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8FC6E51285E4FD828A61BEFD2100CD64;
-			remoteInfo = DifferenceKit;
-		};
-		DA4F6FE206856C654A09E703046B819E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E4D0DCAA1CEF50B24DB0FE6DB58A775E;
-			remoteInfo = Chary;
-		};
-		E07B96CDC104AA6AC6324D70DFC2105C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 6F13695E06195A78EA8A95F8C7ED0D2F;
-			remoteInfo = Nimble;
-		};
-		E71E455E04580E059886BDFB341008B8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4C2EE813FA11F65A8F53AAB9A84C6E08;
-			remoteInfo = "Pods-Artisan_Example";
-		};
-		EFAC8CC4024512658E0745D53FC7F5F7 /* PBXContainerItemProxy */ = {
+		85F6539C30D7117473700A85F141A099 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 222C9BA9370230B670273F42B5E7F810;
 			remoteInfo = DiffableDataSources;
 		};
+		8BF622F0B337A4C958E30F816EF49D3E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ED7AB6873A9DA430A18E0109776D3707;
+			remoteInfo = Builder;
+		};
+		939E67157170BAF52E9D55FB821F4FD6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6A3AC2D6739DCB3DEBEB81CF81B207F2;
+			remoteInfo = Draftsman;
+		};
+		9EE0E6FE8AB87667AEDADEAFE1FDE54D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C2EE813FA11F65A8F53AAB9A84C6E08;
+			remoteInfo = "Pods-Artisan_Example";
+		};
+		B28B3AD0172DF35C742F9D0172DB4425 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ED7AB6873A9DA430A18E0109776D3707;
+			remoteInfo = Builder;
+		};
+		B51F84987B92D4591387E644DD5B6BB5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 222C9BA9370230B670273F42B5E7F810;
+			remoteInfo = DiffableDataSources;
+		};
+		B62A26508AD0B164EB7FE34A6B7DDAAE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0DED92290FC5B4F771B42870DB0A2D55;
+			remoteInfo = Pharos;
+		};
+		BF91963989AE3ED71181993B7B82CB10 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C82891EAB7293DBEE916B21F57E8474D;
+			remoteInfo = Quick;
+		};
+		C6BA210675AB2B8905F3BE18340FA335 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0746DCD7C48E9F6BAB723766294323A;
+			remoteInfo = Clavier;
+		};
+		C7378233E0CD188BF1E1097AB3CBD3A8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 085BD8B607F192AF5EA09EA6EB2E7801;
+			remoteInfo = Impose;
+		};
+		DEB04FA9A67580AAD44BC41BEDCF7B35 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E4D0DCAA1CEF50B24DB0FE6DB58A775E;
+			remoteInfo = Chary;
+		};
+		E6C0BD6C36ADF20FF68138EA443C90E6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E4D0DCAA1CEF50B24DB0FE6DB58A775E;
+			remoteInfo = Chary;
+		};
+		EF9741B1F5322EDC41EB77599001D9C7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0DED92290FC5B4F771B42870DB0A2D55;
+			remoteInfo = Pharos;
+		};
+		F4BAAA470153DACB45D7408458B3A05B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8FC6E51285E4FD828A61BEFD2100CD64;
+			remoteInfo = DifferenceKit;
+		};
+		FD0CA0E2513006FF3E6A0387C5C91416 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F13695E06195A78EA8A95F8C7ED0D2F;
+			remoteInfo = Nimble;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		013F337C417F599D11D7E1AA46A57DED /* MappedObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MappedObservable.swift; path = Pharos/Classes/Relay/MappedObservable.swift; sourceTree = "<group>"; };
-		014DF8974B85AB955C8A9EE26F71ACF8 /* UIApplication+StrictKeyWindow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+StrictKeyWindow.m"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.m"; sourceTree = "<group>"; };
-		01FC711EAA2ACCCC3713CC3206F16BD7 /* DifferenceKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = DifferenceKit.modulemap; sourceTree = "<group>"; };
+		007FEAF3D19E5FEF79EF3B667F04CD9B /* Pharos-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pharos-dummy.m"; sourceTree = "<group>"; };
 		02CDA004F5DCA53CEA3A5163B7D49A7B /* Section.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
-		036911C73F6CEC1C554E5C54D1A3AC05 /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
-		037DB31BFFE1BEB2B9B63504EEF695EE /* StagedChangeset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StagedChangeset.swift; path = Sources/StagedChangeset.swift; sourceTree = "<group>"; };
-		039D2F5BF85464810822619F63ACF2D7 /* Builder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Builder.swift; path = Builder/Classes/Builder.swift; sourceTree = "<group>"; };
-		03C82DAC0C57E365D204090849130501 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
-		03CC20F83553359B1C0A2A26F3882F67 /* Algorithm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Algorithm.swift; path = Sources/Algorithm.swift; sourceTree = "<group>"; };
-		04CD123B00C52F5985BDFFF81F339DD1 /* Pharos-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pharos-umbrella.h"; sourceTree = "<group>"; };
-		0602AEAB65BA2C712609045B5AF61512 /* BindableCollection+UIImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIImageView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIImageView.swift"; sourceTree = "<group>"; };
-		072C9AE6A1259056F7A695A339EF2C4F /* FBSnapshotTestCase.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = FBSnapshotTestCase.modulemap; sourceTree = "<group>"; };
-		0782B8A6426FCB4AB4091CB666D25E91 /* DifferentiableSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DifferentiableSection.swift; path = Sources/DifferentiableSection.swift; sourceTree = "<group>"; };
-		080EC1F735EA930A87CFC5B6B223688F /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
+		040865FA34F88378DC68B67D4B6F39B1 /* Single.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Single.swift; path = Draftsman/Classes/Anchors/Defined/Single.swift; sourceTree = "<group>"; };
+		0415A5C9BF9A2562678007B604AA26BD /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
+		04548115C406B5083D2C4EF6AED037BF /* UIKitExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIKitExtension.swift; path = Sources/Extensions/UIKitExtension.swift; sourceTree = "<group>"; };
+		05D721F6DDD72B4F022CD7391B84C536 /* Builder.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Builder.release.xcconfig; sourceTree = "<group>"; };
+		061F90FFFFE37ACD40F5493C435EF4BB /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
+		0698F24649790E50269FB7B7F9E9D775 /* DifferenceKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "DifferenceKit-dummy.m"; sourceTree = "<group>"; };
+		073843B45712907BA4EB44E78ECE5D9B /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
+		077606C1F799C94688BF86BDBDDE1FD2 /* UniversalError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UniversalError.swift; path = Sources/Internal/UniversalError.swift; sourceTree = "<group>"; };
+		080AA22494874DC9D005B3FEAE1C6894 /* Injector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injector.swift; path = Impose/Classes/Injector.swift; sourceTree = "<group>"; };
 		084FFDD67F09953C61F3564D458239A4 /* LayoutDraft+CellCompatible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LayoutDraft+CellCompatible.swift"; sourceTree = "<group>"; };
+		092B025FA20152BF9A091DDA80929378 /* Chary-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Chary-dummy.m"; sourceTree = "<group>"; };
+		0940FBA73024E0A50FBBA91B5FCD776F /* Builder.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Builder.debug.xcconfig; sourceTree = "<group>"; };
+		09755CE44B8C954939385A3A1DD4C771 /* NSLayoutConstraint+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSLayoutConstraint+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/NSLayoutConstraint+Extensions.swift"; sourceTree = "<group>"; };
+		09A2F81F85C9B07EECF3F60C28D3A732 /* Enumeration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Enumeration.swift; path = Draftsman/Classes/Model/Enumeration.swift; sourceTree = "<group>"; };
 		09A7A9D46F280C289A8B0EF3CE3C0D1F /* Pods-Artisan_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Artisan_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		0A0A4FFDB957CCC11DB3EC8832F223B5 /* Pods-Artisan_Example */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-Artisan_Example"; path = Pods_Artisan_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0A14A4B7BAFF38B8A86BB376CB4A8D80 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
+		0B5B452DFE64C3F186B6A229EC15B95A /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
+		0C231FEE47A69341802AA68B0EAD94DC /* iOSSnapshotTestCase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iOSSnapshotTestCase.release.xcconfig; sourceTree = "<group>"; };
+		0D384368372E08215C8C7F1658F875ED /* TriAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TriAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/TriAnchorRelation.swift; sourceTree = "<group>"; };
 		0D631E9908483F9525A6B3F36F16CC61 /* Quick */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0D7382163DE54559E7DA8CA07A8615A6 /* Builder.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Builder.modulemap; sourceTree = "<group>"; };
-		0DD5047B5EE6841E39808E4DFCFF3921 /* DifferenceKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "DifferenceKit-dummy.m"; sourceTree = "<group>"; };
-		0DD742B226C7AECA5E6FC740C01AE551 /* PrettySyntax.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrettySyntax.swift; path = Nimble_Snapshots/PrettySyntax.swift; sourceTree = "<group>"; };
-		0E15091123661BA326ADCE65EEF5C381 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
+		0E0295041581E98C152C6EAA14C48F97 /* Scopable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scopable.swift; path = Impose/Classes/Scopable.swift; sourceTree = "<group>"; };
 		0E17FFB47D6312F5DF12215EA8C34964 /* Pods-Artisan_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Artisan_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		0F3898660B738CA03CDED30F94DD96A1 /* AnchorPair.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnchorPair.swift; path = Draftsman/Classes/Model/AnchorPair.swift; sourceTree = "<group>"; };
-		0F7D4F7D0291544CE5655A2EBA52B655 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
-		113B2ED3110211EB9C756CA9061B3ED6 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
-		116919CED1B53F03220C837A941F0125 /* FBSnapshotTestCase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FBSnapshotTestCase-dummy.m"; sourceTree = "<group>"; };
-		124233F04C4A8ED9D924A69B7661ED74 /* Nimble-Snapshots-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-Snapshots-dummy.m"; sourceTree = "<group>"; };
-		12A49B1B2813B889E151F3B10563EEE0 /* DiffableDataSources-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DiffableDataSources-prefix.pch"; sourceTree = "<group>"; };
-		12AD0ADA33523EEB4893EDD223B91C33 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
-		1349149C334A58270EE0D3DE80512ADF /* FBSnapshotTestController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = FBSnapshotTestCase/FBSnapshotTestController.m; sourceTree = "<group>"; };
-		13A26E597F85833A5DBEB72D41506ABF /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
-		13C115EB68A03F4967063DB33A5A50AC /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
-		13FFBC3C3BAA8B2193C0EA67D52B6BCA /* DifferenceKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DifferenceKit.release.xcconfig; sourceTree = "<group>"; };
-		140195E1A681EB716339B07AD26AC7DF /* InjectContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InjectContext.swift; path = Impose/Classes/InjectContext.swift; sourceTree = "<group>"; };
-		1476E7577E62B4414BF94FBDD6317E72 /* BindableCollection+TextInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+TextInput.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+TextInput.swift"; sourceTree = "<group>"; };
+		0E8763B81BF79CC14D23ED961EBBDD76 /* Clavier-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Clavier-Info.plist"; sourceTree = "<group>"; };
+		0E88F2FC6E8CEA8850ED0C105DB2C956 /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
+		0F69A269AC77D3F59D202D2142035811 /* FBSnapshotTestController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = FBSnapshotTestCase/FBSnapshotTestController.h; sourceTree = "<group>"; };
+		1073257FF467D61B3567391C3347261B /* Equal+Tuple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Equal+Tuple.swift"; path = "Sources/Nimble/Matchers/Equal+Tuple.swift"; sourceTree = "<group>"; };
+		11DDDF5B0A0F397D66D144F393A337C2 /* BindableCollection+UIScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIScrollView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIScrollView.swift"; sourceTree = "<group>"; };
+		128133987354DBF367D15981472ED297 /* TriAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TriAnchor.swift; path = Draftsman/Classes/Anchors/Base/TriAnchor.swift; sourceTree = "<group>"; };
+		135204924EA6DD3EDDB271B47C115EBD /* UIImage+Diff.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Diff.m"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.m"; sourceTree = "<group>"; };
+		138CE0A74585D52955307BF289A4535F /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
+		13A1B7C72E9CE00F396F3B17812A4BFF /* Nimble-Snapshots-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-Snapshots-prefix.pch"; sourceTree = "<group>"; };
+		140062391D682A565AD648026E4E457D /* QuickConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickConfiguration.swift; path = Sources/Quick/Configuration/QuickConfiguration.swift; sourceTree = "<group>"; };
+		14AAA70E12E4023B8070CB7B61B0CA10 /* BeginWithPrefix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWithPrefix.swift; path = Sources/Nimble/Matchers/BeginWithPrefix.swift; sourceTree = "<group>"; };
 		14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		14DBC7CBDA5471F0BE50D3622F7D5EAF /* Atomic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Atomic.swift; path = Chary/Classes/Atomic.swift; sourceTree = "<group>"; };
-		151419F1D17BB2AFBE291BE6603281DD /* UIImage+Compare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.h"; sourceTree = "<group>"; };
-		166ADDACFA37CB20B20D7C17BFD3270B /* RelayInvoker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RelayInvoker.swift; path = Pharos/Classes/Utils/RelayInvoker.swift; sourceTree = "<group>"; };
-		189C13D561C6C0154E7D6DE283542670 /* Clavier.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Clavier.modulemap; sourceTree = "<group>"; };
-		18E26B8E68FAB43946B433FDE9715CAD /* SingleAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAnchor.swift; path = Draftsman/Classes/Anchors/Base/SingleAnchor.swift; sourceTree = "<group>"; };
-		19543F9F650566C4F4987E4E42013C21 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
+		15AEA58696DE01ED099AE800C305E423 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
+		15B620BE5D0A41075A55ACD16A85699D /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Clavier/Classes/Extensions.swift; sourceTree = "<group>"; };
+		167FC2DFEAF1BE295D182FFF693008C5 /* BindableCollection+UIImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIImageView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIImageView.swift"; sourceTree = "<group>"; };
+		177D1E3CC6CE47EED4125A8CCA49A4A9 /* Quad.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Quad.swift; path = Draftsman/Classes/Anchors/Defined/Quad.swift; sourceTree = "<group>"; };
+		184DAF9B26959C4D115DAF1C9B9D0AF7 /* UIImage+Compare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.h"; sourceTree = "<group>"; };
+		19564BE517BD21456F219972F53F8CE7 /* String+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+C99ExtendedIdentifier.swift"; path = "Sources/Quick/String+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
+		195F5B9E6987992261A5644E7AB5A7E5 /* MappedObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MappedObservable.swift; path = Pharos/Classes/Relay/MappedObservable.swift; sourceTree = "<group>"; };
+		1A148A1ED371EA196D66E562169C764D /* CollectionViewDiffableDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CollectionViewDiffableDataSource.swift; path = Sources/UIKit/CollectionViewDiffableDataSource.swift; sourceTree = "<group>"; };
 		1A2CCA71EFB48934B15450665A084A74 /* Pods-Artisan_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Artisan_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		1A31266FFC30884F7B03B9F82C33DA3B /* CellCompatible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CellCompatible.swift; sourceTree = "<group>"; };
-		1A7D66A22E9C852A4AD90CF06FF85E94 /* Impose-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Impose-prefix.pch"; sourceTree = "<group>"; };
-		1B7B96FFF648DD539AAF8785422B9038 /* AnchorExtractable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnchorExtractable.swift; path = Draftsman/Classes/Anchors/AnchorExtractable.swift; sourceTree = "<group>"; };
-		1BAA31AC885F0732D60994336F6A1B6C /* DimensionAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DimensionAnchor.swift; path = Draftsman/Classes/Anchors/Base/DimensionAnchor.swift; sourceTree = "<group>"; };
-		1BEC56B47AF0597C3979BD00CC0348ED /* Observed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Observed.swift; path = Pharos/Classes/Observable/Observed.swift; sourceTree = "<group>"; };
-		1BFE6958271DB0C607615D388C8B94B9 /* Quick.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.release.xcconfig; sourceTree = "<group>"; };
-		1C27FB4A563905C377EBD921DC727B0A /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
-		1CA73F04757ACE23537A702E730059DF /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Nimble.modulemap; sourceTree = "<group>"; };
-		1CC34CB5D7D09A959721C4D66E80F1C0 /* TriAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TriAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/TriAnchorRelation.swift; sourceTree = "<group>"; };
-		1E0B3185C60C16AE6AF792939B09586B /* ElementPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementPath.swift; path = Sources/ElementPath.swift; sourceTree = "<group>"; };
-		1E87CDA7581F7F55BF08764F6EC8ED4C /* Enumeration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Enumeration.swift; path = Draftsman/Classes/Model/Enumeration.swift; sourceTree = "<group>"; };
+		1AC23AE382126E4156635A2A5203DEF4 /* DimensionAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DimensionAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/DimensionAnchorRelation.swift; sourceTree = "<group>"; };
+		1AE05D6CB733F1E9FF92736AC05AAC74 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
+		1B4DEA5FAA7ACBB2EC4756322C322E3D /* Pharos.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Pharos.modulemap; sourceTree = "<group>"; };
+		1BA0D995518747C79A23B7B4B85A43F4 /* SizeAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SizeAnchor.swift; path = Draftsman/Classes/Anchors/Base/SizeAnchor.swift; sourceTree = "<group>"; };
+		1CBD5BBF10AE1CB5C4FF0C39AE105A1E /* Builder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Builder.swift; path = Builder/Classes/Builder.swift; sourceTree = "<group>"; };
+		1CE9E9D3B34CE0AC817D6BDF956C2532 /* PlanComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlanComponent.swift; path = Draftsman/Classes/Draft/PlanComponent.swift; sourceTree = "<group>"; };
+		1D95A3739747F6D8E5F08B964B1A5CE1 /* MulticastObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MulticastObservable.swift; path = Pharos/Classes/Relay/MulticastObservable.swift; sourceTree = "<group>"; };
 		1EBF379F44CEE2ED81DC82EB0623A7E4 /* Draftsman */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Draftsman; path = Draftsman.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1EE68D6488A4E79BA69B9BC1CC29096F /* Planned.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Planned.swift; path = Draftsman/Classes/Draft/Planned.swift; sourceTree = "<group>"; };
-		1F0EE6D378EE9C97DCFE4E72C8B21079 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
-		1F4C05F15B014CDEFA1D8CE40D529B2D /* Builder.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Builder.debug.xcconfig; sourceTree = "<group>"; };
-		20050F8836F0D81C306516FA337881B7 /* Nimble-Snapshots-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-Snapshots-prefix.pch"; sourceTree = "<group>"; };
+		1F1ABC9A70534A6A278B07A6545A4B3A /* FBSnapshotTestCase.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = FBSnapshotTestCase.modulemap; sourceTree = "<group>"; };
+		1F1B97A754B428D562946AFADB43864D /* SafeAreaKeyboardLayoutGuide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SafeAreaKeyboardLayoutGuide.swift; path = Clavier/Classes/SafeAreaKeyboardLayoutGuide.swift; sourceTree = "<group>"; };
 		204A70EA8EF89FDDB7814F9642AC1AD0 /* ViewBindable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewBindable.swift; sourceTree = "<group>"; };
-		205E5C7A9F4E5987055BB4C5220CC1F0 /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
-		208AFDC82EE25E28BDCC9EDB19CFF78C /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
-		2116703722EDA0171F5C208173B70691 /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCasePlatform.m; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
-		213376EA86515B5196B6CEDB20D9339F /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
-		22B57DA84B91C4D2D992EF3C79B08A93 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
-		230D8ED669AC0AA65B645BCEC992B8E5 /* ImposerCompat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImposerCompat.swift; path = Impose/Classes/ImposerCompat.swift; sourceTree = "<group>"; };
-		238B3705E5F1739794C4528440C69B2C /* Impose-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Impose-dummy.m"; sourceTree = "<group>"; };
+		20576AE59007C9DF9C9F9C11A85EAE24 /* DiffableDataSources-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "DiffableDataSources-dummy.m"; sourceTree = "<group>"; };
+		20EE729E07C1235598D8307EF0E3FF2E /* Quick-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Quick-Info.plist"; sourceTree = "<group>"; };
+		22688060E68A2B16A4411777150EDB18 /* DiffableDataSources.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DiffableDataSources.debug.xcconfig; sourceTree = "<group>"; };
+		234C2930B6808EBED2EDB3A11CA43505 /* FBSnapshotTestController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = FBSnapshotTestCase/FBSnapshotTestController.h; sourceTree = "<group>"; };
 		238D86C6D90DD2A753512AEDF2287DBD /* Artisan.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Artisan.debug.xcconfig; sourceTree = "<group>"; };
-		246BBB114D597989D3FD6CBF785BD540 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
-		24731B08BF7778703311E0388B647FC6 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
-		247FC627095A5289654BCD5EDB3344A8 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
-		24B83A3AEA7348855B89ABB3FCC6249F /* Chary.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Chary.debug.xcconfig; sourceTree = "<group>"; };
-		2525105B63E6CD74069B8CCCA3E85372 /* QuadAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuadAnchor.swift; path = Draftsman/Classes/Anchors/Base/QuadAnchor.swift; sourceTree = "<group>"; };
-		25AF9646DD8EF00609F884B5D0709DB8 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
-		25DF8EC9C18CFF1F4E4ED4E9EC4B6624 /* BeResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeResult.swift; path = Sources/Nimble/Matchers/BeResult.swift; sourceTree = "<group>"; };
-		25ED72AD9B3A49B0A2F044BD6A42AAC1 /* HaveValidSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveValidSnapshot.swift; path = Nimble_Snapshots/HaveValidSnapshot.swift; sourceTree = "<group>"; };
+		2394AADAC17794D0E0F44BE7A3AC9152 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
+		23D7AFC5E1DB6380FD96D386996C7522 /* Array+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/Array+Extensions.swift"; sourceTree = "<group>"; };
+		24C9558AFDB71D8F3CE7422A01AC428A /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
 		264507D64793B8AA56330BA7CD8BB6B8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
 		2775B18D8D33776758AEDE3238E651D0 /* ScrollableStackView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollableStackView.swift; sourceTree = "<group>"; };
-		27E4AA269DA9667341CBE3776BECBE92 /* String+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+C99ExtendedIdentifier.swift"; path = "Sources/Quick/String+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
-		28A12240624413AA73C433E2C28AC1C5 /* TriConstant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TriConstant.swift; path = Draftsman/Classes/Model/TriConstant.swift; sourceTree = "<group>"; };
-		2A05905564051BFAA696F2E24B322369 /* MergedObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MergedObservable.swift; path = Pharos/Classes/Relay/MergedObservable.swift; sourceTree = "<group>"; };
-		2CB8499B9BA02D1623600AEAC915BDAF /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
-		2EB0500D2A0AA5D3649F614BCFE23DBF /* Builder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Builder-prefix.pch"; sourceTree = "<group>"; };
-		2EEF34D60DBF7221FF5C141271DD5E23 /* Pharos-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pharos-dummy.m"; sourceTree = "<group>"; };
-		30667DFA8C29A058183C43DA2B15613A /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
-		31B8A16F787055DA4E2AA900A60FE4E9 /* XCTestObservationCenter+CurrentTestCaseTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+CurrentTestCaseTracker.m"; path = "Nimble_Snapshots/XCTestObservationCenter+CurrentTestCaseTracker.m"; sourceTree = "<group>"; };
-		338DCF99BBA3285919D0EF8C6E24E157 /* DiffableDataSourceSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DiffableDataSourceSnapshot.swift; path = Sources/DiffableDataSourceSnapshot.swift; sourceTree = "<group>"; };
+		27837971E417F85EB03E879791E6F54B /* NBSMockedApplication.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NBSMockedApplication.m; path = Nimble_Snapshots/DynamicType/NBSMockedApplication.m; sourceTree = "<group>"; };
+		282764781C059B0DB57FDACA0C0BB60B /* UIImage+Compare.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Compare.m"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.m"; sourceTree = "<group>"; };
+		28343404E01E6903FA61C3346662FEE1 /* NSLayoutDimension+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSLayoutDimension+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/NSLayoutDimension+Extensions.swift"; sourceTree = "<group>"; };
+		283C3DFC4A7E28D069008748815CF81D /* Chary-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Chary-Info.plist"; sourceTree = "<group>"; };
+		2842061E008A78CC6E094CB36C3E247D /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		2B11DB1DC4C24B95BA829B2B7703289B /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
+		2C02A346FD15D3F5476714B23F5171D1 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
+		2DA30B0E36FABF4B4BEE94393F7CEFB9 /* UIImage+Compare.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Compare.m"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.m"; sourceTree = "<group>"; };
+		2DC0EC031A806026B8DBD5036426CCF4 /* BindableCollection+UITableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UITableView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UITableView.swift"; sourceTree = "<group>"; };
+		2F6108F0CE795ECABEBD357F00D4C740 /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCase.m; path = FBSnapshotTestCase/FBSnapshotTestCase.m; sourceTree = "<group>"; };
+		2FC519DC81C6962CCA4FDA122C485942 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
+		319F4E219DF8828E32FA4DAE77D513A6 /* UIImage+Compare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.h"; sourceTree = "<group>"; };
+		3252F8377525A241629864B054BBAF82 /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
+		32A615C5E78ECA75FC96B04D80CDABAA /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
+		32BA8A8AAC1064893E2A83902BBDDD54 /* ImposerCompat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImposerCompat.swift; path = Impose/Classes/ImposerCompat.swift; sourceTree = "<group>"; };
+		3399C4F6C2473DF25DE82F2EC6CFAF41 /* HaveValidSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveValidSnapshot.swift; path = Nimble_Snapshots/HaveValidSnapshot.swift; sourceTree = "<group>"; };
+		33D39BB5086838B625545698C799FA66 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
 		344489C6BF3C2588F272C28F21C4FC57 /* Builder */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Builder; path = Builder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3486F5ED3D237FD3828F0EF25E658696 /* ModuleProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ModuleProvider.swift; path = Impose/Classes/ModuleProvider.swift; sourceTree = "<group>"; };
-		35AE296C3182345CEC928D48A23B1840 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
-		35D1F4421650691693EEE9DCE38DF9B8 /* ViewPlanBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewPlanBuilder.swift; path = Draftsman/Classes/Draft/ViewPlanBuilder.swift; sourceTree = "<group>"; };
-		361ED4D2FF4042A8D5CE4E45FC756370 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
-		363DE00C624F3969A50A8CEF6082D4D6 /* DimensionAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DimensionAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/DimensionAnchorRelation.swift; sourceTree = "<group>"; };
-		36F4AF68756B46ADEA118A4A0259FFE3 /* ConstraintBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintBuilder.swift; path = Draftsman/Classes/Utilities/ConstraintBuilder.swift; sourceTree = "<group>"; };
-		379D9D9BF59BB007E1C8FC9D850B3C0B /* DispatchTimeInterval.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DispatchTimeInterval.swift; path = Sources/Nimble/Utils/DispatchTimeInterval.swift; sourceTree = "<group>"; };
-		37E1FBC050FF9EC462546E7C5E4DBFA5 /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCase.m; path = FBSnapshotTestCase/FBSnapshotTestCase.m; sourceTree = "<group>"; };
-		38AA40EE0532F8F52AD329802954B1F9 /* Expression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expression.swift; path = Sources/Nimble/Expression.swift; sourceTree = "<group>"; };
-		38C69B45238F09C84A73D8FA656194E1 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
+		359E7CCA46718B35B888F399B903A4B9 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		35DD4433D51ABF748525CAE034B6AF2E /* UIImage+Snapshot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Snapshot.h"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"; sourceTree = "<group>"; };
+		375E45F8DE598CC763884C1B61C38C19 /* SatisfyAllOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAllOf.swift; path = Sources/Nimble/Matchers/SatisfyAllOf.swift; sourceTree = "<group>"; };
+		382A55601270B70E371C84D180E3DD79 /* BindableObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BindableObservable.swift; path = Pharos/Classes/Relay/BindableObservable.swift; sourceTree = "<group>"; };
 		39180F6DE6BDAEB8B3D4BEDEA81031A2 /* Artisan-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Artisan-umbrella.h"; sourceTree = "<group>"; };
-		3A5E0A775E484E6F762BDE377BE09C2D /* DynamicSizeSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DynamicSizeSnapshot.swift; path = Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift; sourceTree = "<group>"; };
-		3A6B75F02C88D51A4CA04DFD44923FB5 /* UIImage+Snapshot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Snapshot.h"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"; sourceTree = "<group>"; };
-		3B34C0DDAE8494B195F94D39B690D727 /* ViewPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewPlan.swift; path = Draftsman/Classes/Draft/ViewPlan.swift; sourceTree = "<group>"; };
-		3B4C315FAA47AD6C9BC4481F16C11390 /* UIApplication+StrictKeyWindow.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIApplication+StrictKeyWindow.h"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.h"; sourceTree = "<group>"; };
-		3B92B6564DCA562E269CE0F36AC7FA45 /* DiffableDataSources.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = DiffableDataSources.modulemap; sourceTree = "<group>"; };
-		3B9FE67E24DEA883C62DF820B4897052 /* Clavier.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Clavier.release.xcconfig; sourceTree = "<group>"; };
+		39EC6212B74498ECCFB32485DC8F995E /* Observable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Observable.swift; path = Pharos/Classes/Observable/Observable.swift; sourceTree = "<group>"; };
+		3AC7A401831533E22D2F837FEEA21494 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		3B534E42655245FAB9C69A4487F1065C /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
+		3B53FDCB52425FA777C6A028903B7A93 /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
 		3CC9ACAA415EAD5D6AE0A28043DECA2F /* Artisan-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Artisan-dummy.m"; sourceTree = "<group>"; };
+		3CCAF70F682FDCBD18B53CD120AE86CB /* LayoutDraftBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutDraftBuilder.swift; path = Draftsman/Classes/Utilities/LayoutDraftBuilder.swift; sourceTree = "<group>"; };
+		3D3AC22A74BF5FD2CACCE09BE89A3EE3 /* PrettySyntax.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrettySyntax.swift; path = Nimble_Snapshots/PrettySyntax.swift; sourceTree = "<group>"; };
+		3D98D74A637620C3F25F0B45F1D33A60 /* FBSnapshotTestController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = FBSnapshotTestCase/FBSnapshotTestController.m; sourceTree = "<group>"; };
+		3DF5C2ABFBE30CA66E8118A7D53882D8 /* Algorithm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Algorithm.swift; path = Sources/Algorithm.swift; sourceTree = "<group>"; };
+		3E2D13FB9F1CF20CAE868B0FEDF63123 /* DimensionAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DimensionAnchor.swift; path = Draftsman/Classes/Anchors/Base/DimensionAnchor.swift; sourceTree = "<group>"; };
 		3E6B515B7206879DDA3C84F791FC3FCF /* Pods-Artisan_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Artisan_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		3EC71B5B5F7E28282392D4AB25855397 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
 		3ED64C613828C3F89B4683946C466B2E /* TypeAliases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TypeAliases.swift; sourceTree = "<group>"; };
-		3F1EE23730ACF8D9942E2731CC18F2C8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		3F831D762664684524DA3F196496B5F1 /* PairAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/PairAnchorRelation.swift; sourceTree = "<group>"; };
-		4004351F331CDA599C0EE531AE4354E8 /* PlanComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlanComponent.swift; path = Draftsman/Classes/Draft/PlanComponent.swift; sourceTree = "<group>"; };
-		419B1E0D34FBB374618C2B9B4F9A35CC /* Pharos.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pharos.release.xcconfig; sourceTree = "<group>"; };
-		43C5F566B893CC8892D0CA988BBC3DE4 /* Pharos-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pharos-Info.plist"; sourceTree = "<group>"; };
-		43E0A5C89B7E50AA6958466482117588 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
+		3F1EE23730ACF8D9942E2731CC18F2C8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		4019D69E26028750627268554B9EA028 /* Nimble-Snapshots-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Snapshots-Info.plist"; sourceTree = "<group>"; };
+		41C92E3B75B8BB489E56022BC5A65376 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
+		421F80C00CEFC13B1384C59BBD8A2E49 /* LayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutPlan.swift; path = Draftsman/Classes/Draft/LayoutPlan.swift; sourceTree = "<group>"; };
+		4262D15483B148E863D8AD635B8248B3 /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCasePlatform.m; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
+		42A166E4F28EE1901F0E1F1E24FB54ED /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
+		43FE248E6C827424F70FCA7E36086ECA /* UIControl+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIControl+Extensions.swift"; path = "Pharos/Classes/UIControl/UIControl+Extensions.swift"; sourceTree = "<group>"; };
+		44AE95E5F5D1D0E395A6DBDCACAEFA2F /* SingleAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAnchor.swift; path = Draftsman/Classes/Anchors/Base/SingleAnchor.swift; sourceTree = "<group>"; };
 		451067079A0D0784EBB644C73B45F577 /* CellBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CellBuilder.swift; sourceTree = "<group>"; };
-		4535E8162B56FA4819A46D4475072AEE /* Clavier-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Clavier-umbrella.h"; sourceTree = "<group>"; };
-		461A6EA77ED58EF823CFB13ED29303D9 /* DiffableDataSourceCore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DiffableDataSourceCore.swift; path = Sources/Internal/DiffableDataSourceCore.swift; sourceTree = "<group>"; };
-		467664C80243597EA4403F1CB2686513 /* Pair.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Pair.swift; path = Draftsman/Classes/Anchors/Defined/Pair.swift; sourceTree = "<group>"; };
-		467B43AAF430D3A0043CEC7ACEE9BD83 /* LayoutAxisAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutAxisAnchor.swift; path = Draftsman/Classes/Anchors/LayoutAxisAnchor.swift; sourceTree = "<group>"; };
-		47E2C2FEFF5FB3BDF0F73F62177FF04A /* Nimble_Snapshots.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble_Snapshots.h; path = Nimble_Snapshots/Nimble_Snapshots.h; sourceTree = "<group>"; };
-		481AB0A8186CFE0CAB0B664C83E7ABE1 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
-		48477023D234FAAC61E96CA0555A8495 /* Draftsman.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Draftsman.release.xcconfig; sourceTree = "<group>"; };
-		48F7B317972059C369AFE5379DFDB5A3 /* PopulatedRelays.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PopulatedRelays.swift; path = Pharos/Classes/PopulatedRelays/PopulatedRelays.swift; sourceTree = "<group>"; };
-		491828D6127E09592D5F8141593540C2 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
+		4580972A7EE536DDC3991BA43667E65E /* AnchorExtractable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnchorExtractable.swift; path = Draftsman/Classes/Anchors/AnchorExtractable.swift; sourceTree = "<group>"; };
+		458CA75E910B9A310B1E7028A4AD0F2F /* Clavier-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Clavier-prefix.pch"; sourceTree = "<group>"; };
+		4868EF6D73C9BECA98DE6E7824EF7F70 /* SizeAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SizeAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/SizeAnchorRelation.swift; sourceTree = "<group>"; };
+		496C445CE5F70C0D6255CE0989598E46 /* BindableCollection+TextInput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+TextInput.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+TextInput.swift"; sourceTree = "<group>"; };
 		4A321BFA6052FE6B5BD5AB4570F4063E /* ViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
-		4A5185DD992ED573D51556BF905AEB90 /* IdentifiedAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IdentifiedAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/IdentifiedAnchorRelation.swift; sourceTree = "<group>"; };
+		4AC67F065CF5BC781DC993A55BD4772F /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
+		4AF71DB9FC15504A681CDE32E585F700 /* BindableCollection+UIStackView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIStackView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIStackView.swift"; sourceTree = "<group>"; };
 		4B3AE45F5B3A4DFBC211383589AF4753 /* Pods-Artisan_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Artisan_Tests-Info.plist"; sourceTree = "<group>"; };
-		4B76772AB1A7281813E7595D579C25F2 /* Retainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Retainer.swift; path = Pharos/Classes/Model/Retainer.swift; sourceTree = "<group>"; };
-		4BB0BF618D589C9E452FBDD4532270B8 /* BindableCollection+UIStepper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIStepper.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIStepper.swift"; sourceTree = "<group>"; };
-		4BE5F2D356B1DC3B2AAEAB6F9501BF22 /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
-		4C2105906B93F65A2F49738C2F73D344 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		4C5E9E3B03D1A8AAA9222E50F3F5C893 /* ImposeError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImposeError.swift; path = Impose/Classes/ImposeError.swift; sourceTree = "<group>"; };
-		4E00BDD6380CA33853243E54C2A817AE /* Impose.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Impose.release.xcconfig; sourceTree = "<group>"; };
-		4EF3A019400B5734A24B45703228637B /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
-		4FA619C6BFEE11975D4BD6CA70F7623E /* DiffableDataSources-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DiffableDataSources-umbrella.h"; sourceTree = "<group>"; };
-		4FDBDF140EC034E0BAD97E6742F33BC9 /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
+		4B60884EEFBE9DC817336288FBAF5A7E /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Extensions.swift"; path = "Chary/Classes/DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
+		4BFBFB8102BC67FCF7EEE9B108A70FB6 /* BindableKVOObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BindableKVOObservable.swift; path = Pharos/Classes/Relay/BindableKVOObservable.swift; sourceTree = "<group>"; };
+		4C06E3445C4F18D29E68F5DFF3CCF9F1 /* DifferenceKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DifferenceKit-umbrella.h"; sourceTree = "<group>"; };
+		4C78966D39E8E662EDE0E59F01DBFC43 /* IdentifiedAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IdentifiedAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/IdentifiedAnchorRelation.swift; sourceTree = "<group>"; };
+		4E54AF4ABCCADB83C4BA93AEDB2A2D32 /* NBSMockedApplication.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NBSMockedApplication.h; path = Nimble_Snapshots/DynamicType/NBSMockedApplication.h; sourceTree = "<group>"; };
+		4F4AD0DD2AA7544F961631D73670F17D /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
+		4F82CC7A3FFC71B7A0F1166DAFA6EA23 /* DiffableDataSources-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DiffableDataSources-umbrella.h"; sourceTree = "<group>"; };
+		4F86955306047FF945EE406376D988C7 /* Impose.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Impose.release.xcconfig; sourceTree = "<group>"; };
 		50271E1883DFDC6A920E9F52FC419E4A /* Artisan-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Artisan-Info.plist"; sourceTree = "<group>"; };
+		5035C15F1998776D6A7BF4CCE12BC7B9 /* HaveValidDynamicTypeSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveValidDynamicTypeSnapshot.swift; path = Nimble_Snapshots/DynamicType/HaveValidDynamicTypeSnapshot.swift; sourceTree = "<group>"; };
 		507BF2337BAAFF260BCDECBB72741CB7 /* Clavier */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Clavier; path = Clavier.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		50932CBD0F89EC874A1D690E202EFF00 /* BindableCollection+UISlider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UISlider.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UISlider.swift"; sourceTree = "<group>"; };
-		50A9942D2C54ACE9FD03CC16950143E5 /* UIImage+Snapshot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Snapshot.m"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.m"; sourceTree = "<group>"; };
-		51CEFB7928E2BE82AFA4DEC9A9952D72 /* Differentiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Differentiable.swift; path = Sources/Differentiable.swift; sourceTree = "<group>"; };
+		50E6CB9489E0FD254CEA852EE8A7CD35 /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCasePlatform.m; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
+		50FBBA947BEE1065C7BE95C98378F011 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
 		51D6A9245482A20D3BAF9295BDDCF22B /* Pods-Artisan_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Artisan_Tests-umbrella.h"; sourceTree = "<group>"; };
+		5229633E4CDE069F5A7E47E563E10F22 /* Nimble-Snapshots.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Nimble-Snapshots.release.xcconfig"; sourceTree = "<group>"; };
 		52C1B30CC4697E1933141720223103BC /* Nimble-Snapshots */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Nimble-Snapshots"; path = Nimble_Snapshots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		53A8803D10A2BDE2A00EC9C3A280DE2F /* Quick.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.debug.xcconfig; sourceTree = "<group>"; };
-		53C80243E51F301DB348092DB75C211C /* Nimble.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.debug.xcconfig; sourceTree = "<group>"; };
-		560F0259FE9CF1CD6C1CB28DB49CECFF /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
-		56B4ACC27BC777A02CF3E46AA2ECD3AE /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
-		596B36A1643F56BF912E08FF0BD7616F /* UIImage+Diff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Diff.h"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.h"; sourceTree = "<group>"; };
-		598E95839933806B8921D5C8DE28F6C0 /* TableViewDiffableDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TableViewDiffableDataSource.swift; path = Sources/UIKit/TableViewDiffableDataSource.swift; sourceTree = "<group>"; };
-		5A6888AAD71BBDE61BFD3AAF42213C1F /* Builder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Builder-dummy.m"; sourceTree = "<group>"; };
-		5B0A4E88409BA10522587F165FA92820 /* QCKConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QCKConfiguration.swift; path = Sources/Quick/Configuration/QCKConfiguration.swift; sourceTree = "<group>"; };
-		5B9940116E1153DACAD38FA9A34C30A9 /* BindableCollection+UILabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UILabel.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UILabel.swift"; sourceTree = "<group>"; };
-		5C0AC4EEB7D237989BF921F123FA80B6 /* Trio.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Trio.swift; path = Draftsman/Classes/Anchors/Defined/Trio.swift; sourceTree = "<group>"; };
+		52C357CC4F83E907EBC7C57371695010 /* ObjectRetainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjectRetainer.swift; path = Pharos/Classes/Model/ObjectRetainer.swift; sourceTree = "<group>"; };
+		532A0F77815F32D8E92CAF614C7F79DD /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
+		537B0813DF8853E15EAB48020BC37C99 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
+		541FA35F2A62EF0A9C0304AD7C4CC98C /* Pharos-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pharos-umbrella.h"; sourceTree = "<group>"; };
+		558025F2AF4CCA6D7D76F2E9708B695B /* UIImage+Diff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Diff.h"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.h"; sourceTree = "<group>"; };
+		55F88247D714C9BCECBBF8652FE7C349 /* Impose.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Impose.debug.xcconfig; sourceTree = "<group>"; };
+		57751974DD2DA624E2A6EF34F6CC73D1 /* Draftsman-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Draftsman-umbrella.h"; sourceTree = "<group>"; };
+		57855198631521F118E62272838F7932 /* FBSnapshotTestCase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FBSnapshotTestCase-prefix.pch"; sourceTree = "<group>"; };
+		57947969E6D853BA69C70D02F764123B /* ModuleProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ModuleProvider.swift; path = Impose/Classes/ModuleProvider.swift; sourceTree = "<group>"; };
+		57AD3D9B819ECE13AACD57CEF8CA9C4B /* BindableCollection+UIButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIButton.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIButton.swift"; sourceTree = "<group>"; };
+		59BB44E8E1EC29EBAC3D595062201982 /* Observed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Observed.swift; path = Pharos/Classes/Observable/Observed.swift; sourceTree = "<group>"; };
+		5AA902042566B507F124F51C452215E5 /* Publisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Publisher.swift; path = Pharos/Classes/Relay/Publisher.swift; sourceTree = "<group>"; };
+		5AB3E94ACBAF641ECBEBFD3020E8FACC /* Builder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Builder-prefix.pch"; sourceTree = "<group>"; };
+		5B32C665DB63D5618BEA62D30CBBA8E9 /* AnchorPair.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnchorPair.swift; path = Draftsman/Classes/Model/AnchorPair.swift; sourceTree = "<group>"; };
+		5BE773968DFE2AB171E4732B22BA4372 /* FBSnapshotTestCase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FBSnapshotTestCase.release.xcconfig; sourceTree = "<group>"; };
+		5C18842FCD6A73C7B087A5A9C434C5A2 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
 		5C4F31330DFA99D699E4BDC8C3573D73 /* FBSnapshotTestCase */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = FBSnapshotTestCase; path = FBSnapshotTestCase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5C8B34DB23A19B22E3DAE3E50BEBBCDD /* UIImage+Diff.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Diff.m"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.m"; sourceTree = "<group>"; };
-		5E3D399F3A1E2617F98BD948AF3555BB /* iOSSnapshotTestCase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "iOSSnapshotTestCase-dummy.m"; sourceTree = "<group>"; };
-		5EFD3CCCCE07CE0D1393442A2D71CC3F /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
-		5F0403B771FD9C4E62D1CB303801A276 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
-		5F3AFC1B1E1786D2FB423F613E03C250 /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Clavier/Classes/Extensions.swift; sourceTree = "<group>"; };
+		5D18FF4F783101567C65818ADD0AC5FC /* FBSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "FBSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
+		5D29A2980DF760562AF1E27A12D163A5 /* PropertyAssigner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PropertyAssigner.swift; path = Builder/Classes/PropertyAssigner.swift; sourceTree = "<group>"; };
+		5D5C64EC41ADFD2C50C433A33EBF7B13 /* UIApplication+StrictKeyWindow.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIApplication+StrictKeyWindow.h"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.h"; sourceTree = "<group>"; };
+		5D92F4723D78E0860F1944E726237418 /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
+		5DA8297BEC6EF6CDD2277BD12B197448 /* LayoutAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutAnchor.swift; path = Draftsman/Classes/Anchors/LayoutAnchor.swift; sourceTree = "<group>"; };
 		5F739F48AC0A7ABA5F405DF0FE96B646 /* Pods-Artisan_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Artisan_Example-Info.plist"; sourceTree = "<group>"; };
-		5FD93D2494BDC47F3D6375B3627185B4 /* CollectionViewDiffableDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CollectionViewDiffableDataSource.swift; path = Sources/UIKit/CollectionViewDiffableDataSource.swift; sourceTree = "<group>"; };
-		6053046482A15766D6A1C2DEF70B8A5F /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
-		6099106B973F821CEA355FD132DF0C11 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		615BC8C141C6F89AE0566E05E73B9E55 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
-		61D212BDC8D8434D70AE6958814A8AF3 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
-		637217F02BB06F450F12E4594C1BB921 /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCasePlatform.h; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
-		65CECF18F545C9F447A05B0E382C439F /* ContentIdentifiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentIdentifiable.swift; path = Sources/ContentIdentifiable.swift; sourceTree = "<group>"; };
-		65E8B2D287DC125B5C365739F1B490BA /* FBSnapshotTestCase-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FBSnapshotTestCase-umbrella.h"; sourceTree = "<group>"; };
-		66CB24D864E2B9EDE7065C65EB77765F /* SizeAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SizeAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/SizeAnchorRelation.swift; sourceTree = "<group>"; };
-		6843374F3B004144301DCBA87669EFC6 /* Observable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Observable.swift; path = Pharos/Classes/Observable/Observable.swift; sourceTree = "<group>"; };
-		684B3930A71D239368783ED680809ED6 /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		6927E9BF13E65861749978D859C967E2 /* Mirror+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Mirror+Extensions.swift"; path = "Impose/Classes/Mirror+Extensions.swift"; sourceTree = "<group>"; };
-		69F3063851CB50979EFE5A7D230758BA /* LayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutPlan.swift; path = Draftsman/Classes/Draft/LayoutPlan.swift; sourceTree = "<group>"; };
-		6A57D62C8FBDEEDBA8021BF1E4767684 /* QuickObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickObjCRuntime.h; path = Sources/QuickObjCRuntime/include/QuickObjCRuntime.h; sourceTree = "<group>"; };
-		6A5C7D0634FEC0A3A4B7737E0C93F71E /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
+		60429C7B7502FD8F4E0D576B78BE80C0 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
+		6099106B973F821CEA355FD132DF0C11 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		6115345D980F0556C6332245CA345F5A /* AnyDifferentiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyDifferentiable.swift; path = Sources/AnyDifferentiable.swift; sourceTree = "<group>"; };
+		61E793A0179FC848D812A8C566E36B99 /* PropertyWrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PropertyWrapper.swift; path = Impose/Classes/PropertyWrapper.swift; sourceTree = "<group>"; };
+		61ED5ED8415D32B291E1BC644D71952E /* UIKit+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIKit+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/UIKit+Extensions.swift"; sourceTree = "<group>"; };
+		62FD94A9BB3F36AB27646DE937182371 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
+		632A143858BE02B2BE015727F857E8BB /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
+		6369A57BB4DF6BA0969372DC56D987B4 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
+		63773A0754DDFB345DDB4958B2171E8A /* BindableCollection+UISwitch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UISwitch.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UISwitch.swift"; sourceTree = "<group>"; };
+		6572DD077B69C33A0869ADB1F914861F /* ConstraintBuilderRootRecoverable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintBuilderRootRecoverable.swift; path = Draftsman/Classes/Anchors/ConstraintBuilderRootRecoverable.swift; sourceTree = "<group>"; };
+		678AF299CA04FAD3698E4BC6CEDE6871 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
+		682649E7A29187C4F4AC2054C6C56E8A /* Builder.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Builder.modulemap; sourceTree = "<group>"; };
+		689EA5A8322AEB80986A7F134CDC2EC2 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
+		69874B3F269F3E5EF41C576485A481B7 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
 		6A7C46E2D61F96106CF4CDEDC0C6D4D8 /* StackBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StackBuilder.swift; sourceTree = "<group>"; };
-		6B1C4F95C5FF88166E7B00C4EBA62642 /* Pharos.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Pharos.modulemap; sourceTree = "<group>"; };
-		6B731C52788415156A8F37A1F6B32281 /* Nimble-Snapshots.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Nimble-Snapshots.release.xcconfig"; sourceTree = "<group>"; };
-		6BA07CF6F10CF589A79C080EF0A97BA3 /* BindableCollection+UISwitch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UISwitch.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UISwitch.swift"; sourceTree = "<group>"; };
-		6C22125074FB5EA22E43C2569D5D6780 /* UIView+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/UIView+Extensions.swift"; sourceTree = "<group>"; };
-		6D36A7DA4746275C769F85C62F1C1C18 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extensions.swift"; path = "Impose/Classes/Dictionary+Extensions.swift"; sourceTree = "<group>"; };
-		6F7EDFC4395005DE3CFC31334A4AB40D /* TypeHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TypeHashable.swift; path = Impose/Classes/TypeHashable.swift; sourceTree = "<group>"; };
-		6FE8561F30C072431561A4DCB25891B1 /* ArraySection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArraySection.swift; path = Sources/ArraySection.swift; sourceTree = "<group>"; };
-		7048EAB14F18A05F850568C13C63F3EC /* Impose.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Impose.debug.xcconfig; sourceTree = "<group>"; };
-		704F2C4AFEE84BF6378E879AF0E10205 /* ExampleMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleMetadata.swift; path = Sources/Quick/ExampleMetadata.swift; sourceTree = "<group>"; };
-		707153269BF13501493C162D115689EF /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
-		714A3DFFC439A48E1389C9951C917675 /* Nimble-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Info.plist"; sourceTree = "<group>"; };
+		6AB4B50F8B3B44F718F04C4767E2AA13 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
+		6B2F30EDF3E8E72C7722AB25C8483656 /* Pharos.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pharos.release.xcconfig; sourceTree = "<group>"; };
+		6B3BA0BCB0DE172930CBEF888CFF73EB /* ArraySection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArraySection.swift; path = Sources/ArraySection.swift; sourceTree = "<group>"; };
+		6B5C17DC79943927CE4CB57CEAFEC047 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		6B7629630622DA71E4B7D0AFD598B206 /* ViewPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewPlan.swift; path = Draftsman/Classes/Draft/ViewPlan.swift; sourceTree = "<group>"; };
+		6DE5CB2B34860BC739B5B3E30676774A /* BindableCollectionCellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BindableCollectionCellView.swift; path = Pharos/Classes/PopulatedRelays/BindableCollectionCellView.swift; sourceTree = "<group>"; };
+		6E24FE81A643C5BF30D89D91A5A16CB9 /* NimbleEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleEnvironment.swift; path = Sources/Nimble/Adapters/NimbleEnvironment.swift; sourceTree = "<group>"; };
+		6F1765C8C3C2398470CECF4BF768BBF3 /* UIImage+Snapshot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Snapshot.h"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"; sourceTree = "<group>"; };
+		72359285018337286FC39596CA366C49 /* ElementPath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementPath.swift; path = Sources/ElementPath.swift; sourceTree = "<group>"; };
 		723CCBCBE0E40EE2E07AE84B61FD3811 /* Pods-Artisan_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Artisan_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		726D79DC7EAC9314100EA8E05D1DCD27 /* FBSnapshotTestCase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FBSnapshotTestCase-prefix.pch"; sourceTree = "<group>"; };
-		72A76C7B0359AB60C345E0243CE8AC43 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
-		73AA1B343A02AE3F34FDD51FCFA8E697 /* ObservableBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableBlock.swift; path = Pharos/Classes/Relay/ObservableBlock.swift; sourceTree = "<group>"; };
+		72E0049ED94E764B84FAEF0115C91084 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
+		73655E683AB52450A1CA90262E8A05CD /* QuadAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuadAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/QuadAnchorRelation.swift; sourceTree = "<group>"; };
+		736AD2086D82A47487CAE44FF912DFB8 /* Nimble.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.debug.xcconfig; sourceTree = "<group>"; };
+		738DB8348A74CF2E7BBADC057CEE838B /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
+		73C2CED58F9B57BED8B86CE735BB3106 /* Chary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Chary-prefix.pch"; sourceTree = "<group>"; };
 		74F761ABE3518B3CFC6643F184DBEC3F /* Pods-Artisan_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Artisan_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		7547B7B3C8005E3B8079DC61E0651AAE /* TriAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TriAnchor.swift; path = Draftsman/Classes/Anchors/Base/TriAnchor.swift; sourceTree = "<group>"; };
-		75E93D1ECF93B321BD6EBA755387AB13 /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
-		764FD06EF0185123816A74099FA09DCF /* ContentEquatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentEquatable.swift; path = Sources/ContentEquatable.swift; sourceTree = "<group>"; };
-		774905AEF7F4E7B36C64127F70355052 /* Draftsman-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Draftsman-Info.plist"; sourceTree = "<group>"; };
-		77AE0350F61BF5BCAE1037D76874C50A /* Array+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Array+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/Array+Extensions.swift"; sourceTree = "<group>"; };
-		78A405D063F46996923F534D8CEBF239 /* DifferenceKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "DifferenceKit-Info.plist"; sourceTree = "<group>"; };
-		78C08F3164FC77E466D6A3CD454C74E5 /* FBSnapshotTestCase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FBSnapshotTestCase.release.xcconfig; sourceTree = "<group>"; };
+		77127953399AB2C7DA555E1F602A82E0 /* SingleAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/SingleAnchorRelation.swift; sourceTree = "<group>"; };
+		771BA57969418A28D008EA70AC1428AE /* HashableExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HashableExtension.swift; path = Sources/Internal/HashableExtension.swift; sourceTree = "<group>"; };
+		775ED9FA2E33C3C4F22F7ABA1AEC19CC /* Chary.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Chary.debug.xcconfig; sourceTree = "<group>"; };
+		780C99873DB13B4722413879850158E2 /* Differentiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Differentiable.swift; path = Sources/Differentiable.swift; sourceTree = "<group>"; };
+		78DF786636EC17F6841EC06F62533D8C /* Draftsman-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Draftsman-prefix.pch"; sourceTree = "<group>"; };
 		790C5BBF272E683A7E021621F735FF55 /* Chary */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Chary; path = Chary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		795C671C529F20CE73E4721AAB8F6809 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
 		797B1BBC3E03CD39B8CB79D79BCFF843 /* DifferenceKit */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DifferenceKit; path = DifferenceKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		79B940F31E7DCE39678C3E125F3A69A0 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
-		7ABDE83C8DF944F8AFB50BEFED09C5C9 /* HashableExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HashableExtension.swift; path = Sources/Internal/HashableExtension.swift; sourceTree = "<group>"; };
-		7BB8F4FD65984DA69BB3B7FA10CECF21 /* BindableKVOObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BindableKVOObservable.swift; path = Pharos/Classes/Relay/BindableKVOObservable.swift; sourceTree = "<group>"; };
-		7BFE1652DFB1A6C20E2E725000E8B0E6 /* PharosContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PharosContext.swift; path = Pharos/Classes/Model/PharosContext.swift; sourceTree = "<group>"; };
-		7CA99F85DB68C7BBF5356E0AD2292AFF /* FBSnapshotTestCase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FBSnapshotTestCase.debug.xcconfig; sourceTree = "<group>"; };
-		7D324A4C7A3320D7A3B34F8591B04F2C /* iOSSnapshotTestCase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iOSSnapshotTestCase.release.xcconfig; sourceTree = "<group>"; };
+		79CD87051B354E1AA997F90BEEE728E4 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
+		7A3FF6B6B6C9922767CCAE37D2DC3486 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
+		7ACB45BF5DE830982F05C2CDDF953780 /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
+		7ADFD21EDD7BC59AA71C74FA1EC65EE5 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
+		7BBF38670333C8645413823A58DF3ACC /* DifferenceKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DifferenceKit.debug.xcconfig; sourceTree = "<group>"; };
+		7EEA129A74B9B8ADC38251EA4409F55E /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
+		7F5706ABA08EAE92689544B4A57E2BF8 /* StackCompatible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StackCompatible.swift; path = Draftsman/Classes/Utilities/StackCompatible.swift; sourceTree = "<group>"; };
 		7F7DCA21EB27BA1BE97F1AC6C7F8DD6D /* Pods-Artisan_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Artisan_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		80F3FB96FA13DB499426A23FA7816700 /* UIImage+Compare.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Compare.m"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.m"; sourceTree = "<group>"; };
-		814D6D5CAF570678DCA959940879DC39 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
-		81FBE2A955107533A9126772B9F980BB /* iOSSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "iOSSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
-		824E2426D17BA9CB5A3CD3DF7A6337D8 /* Draftsman-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Draftsman-umbrella.h"; sourceTree = "<group>"; };
-		83D7F72D0D89433A0A38899D2491842E /* DifferenceKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DifferenceKit.debug.xcconfig; sourceTree = "<group>"; };
-		85E8621C5B92ACE1CFE113E2F824881E /* PropertyWrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PropertyWrapper.swift; path = Impose/Classes/PropertyWrapper.swift; sourceTree = "<group>"; };
-		8605ED7B5C71FB407B2F6113BA5B6512 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
-		866D90BA278E42189EEDB2D2FBB39964 /* DiffableDataSources-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "DiffableDataSources-dummy.m"; sourceTree = "<group>"; };
-		86D0AFFD87077DBB90BE1F4457E0AF98 /* Chary-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Chary-Info.plist"; sourceTree = "<group>"; };
-		887317B216A4BCCE5DD7F88F40D95831 /* PairAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairAnchor.swift; path = Draftsman/Classes/Anchors/Base/PairAnchor.swift; sourceTree = "<group>"; };
-		8894E94E09A813B56AAF7F9A0408DB61 /* PrettyDynamicTypeSyntax.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrettyDynamicTypeSyntax.swift; path = Nimble_Snapshots/DynamicType/PrettyDynamicTypeSyntax.swift; sourceTree = "<group>"; };
-		88C6BB2302184FCDDD2766D6A1A9AE2C /* BaseProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseProtocols.swift; path = Pharos/Classes/Relay/BaseProtocols.swift; sourceTree = "<group>"; };
-		89B6D072DB73E3F7D011511BE01FD688 /* QuickTestSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestSuite.swift; path = Sources/Quick/QuickTestSuite.swift; sourceTree = "<group>"; };
-		8AB6C7B5066447F0A7DA7B5429D95B08 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
-		8B11432EA47C88167C2BA72B5E702DF4 /* MulticastObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MulticastObservable.swift; path = Pharos/Classes/Relay/MulticastObservable.swift; sourceTree = "<group>"; };
-		8C6D2F146291D9143E041E631C67E3DB /* PropertyAssigner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PropertyAssigner.swift; path = Builder/Classes/PropertyAssigner.swift; sourceTree = "<group>"; };
-		8D4B3143E105F6047E8E8377A2E8F225 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
-		8D543A275A56B9790A70AB7F4B8F0D17 /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
-		8E25CA2115280857E254C83343CEF68F /* Builder-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Builder-umbrella.h"; sourceTree = "<group>"; };
-		8FBC34FBDA58317A391F56CAB5BB5003 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
-		8FF36F5D0CE99E6FC7261A5575530B30 /* ObjectRetainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjectRetainer.swift; path = Pharos/Classes/Model/ObjectRetainer.swift; sourceTree = "<group>"; };
+		81500AF4AFA894D9404262ACBD9274FB /* FilteredObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilteredObservable.swift; path = Pharos/Classes/Relay/FilteredObservable.swift; sourceTree = "<group>"; };
+		8215801333035857FBFC89E285C49053 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CurrentTestCaseTracker.swift; path = Nimble_Snapshots/CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
+		82534E64080EFDF31CE186AC81026BFB /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
+		839651B9A3ED124E05D79285E1342857 /* MainThreadSerialDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainThreadSerialDispatcher.swift; path = Sources/Internal/MainThreadSerialDispatcher.swift; sourceTree = "<group>"; };
+		83D3927C9DDD1E4A603F8CAD3783B0E5 /* Pharos-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pharos-Info.plist"; sourceTree = "<group>"; };
+		83EAB420B92C4CADBDD8BFBACDC83EF5 /* Subject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subject.swift; path = Pharos/Classes/Observable/Subject.swift; sourceTree = "<group>"; };
+		85EC89C31D92EBD7585C66594467491C /* BindableCollection+UILabel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UILabel.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UILabel.swift"; sourceTree = "<group>"; };
+		862B7E338C8F5ED7AE930AAA01E7A87E /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
+		863F7DD09E142C5FAC8FBAE1EE9EB761 /* DiffableDataSources.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = DiffableDataSources.modulemap; sourceTree = "<group>"; };
+		86BF674E0F63FCE2C2FF5EEB81C1CC33 /* Impose-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Impose-Info.plist"; sourceTree = "<group>"; };
+		87BFB9FF4B3FFD029A1F6401F9840F3A /* PharosContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PharosContext.swift; path = Pharos/Classes/Model/PharosContext.swift; sourceTree = "<group>"; };
+		883A0229A960E1F7517BE56CCFFE0E3B /* PairAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairAnchor.swift; path = Draftsman/Classes/Anchors/Base/PairAnchor.swift; sourceTree = "<group>"; };
+		885CBCD48419B456B584D2EB5B8C01C7 /* Nimble-Snapshots.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Nimble-Snapshots.modulemap"; sourceTree = "<group>"; };
+		8869248C4992F8BE4A115183C02FDC34 /* AxisAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AxisAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/AxisAnchorRelation.swift; sourceTree = "<group>"; };
+		88F2B3D13A94367B19D0B7834299462C /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
+		8A1EDAAA84402FD96B5DFCD097F99F7F /* Changes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Changes.swift; path = Pharos/Classes/Model/Changes.swift; sourceTree = "<group>"; };
+		8A21DD4FFD20C66A685AE00C08503232 /* UIApplication+StrictKeyWindow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+StrictKeyWindow.m"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.m"; sourceTree = "<group>"; };
+		8A93A1036ED2EC26102002AFAED3A135 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = FBSnapshotTestCase/SwiftSupport.swift; sourceTree = "<group>"; };
+		8B57699296657D79CAA785094F2473FE /* DynamicSizeSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DynamicSizeSnapshot.swift; path = Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift; sourceTree = "<group>"; };
+		8BC1EDB602505BD76D34AE87C42765BE /* World.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = World.swift; path = Sources/Quick/World.swift; sourceTree = "<group>"; };
+		8C1B40929DF06C32BF05A995C0D946F8 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
+		8C40F41CC267DEF04A76CE0C47AC8C04 /* Builder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Builder-dummy.m"; sourceTree = "<group>"; };
+		8D4220988B6F1501CF122C8127F73416 /* PrioritizedAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrioritizedAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/PrioritizedAnchorRelation.swift; sourceTree = "<group>"; };
+		8D46B055BA3B982118DA31D58B699444 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		8DF48F49DD204444B1019B81C975C2EE /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
+		8E5836EA5E75BBBC12707CDB1CFD6A93 /* BeVoid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeVoid.swift; path = Sources/Nimble/Matchers/BeVoid.swift; sourceTree = "<group>"; };
+		8F38BE71F309685F2FBB4E97C07762CA /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
+		8F79D8669C7DADB8D9B17B0206628CCA /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
+		9014FC05E8F6E9C0478938C470E53ED0 /* ContentIdentifiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentIdentifiable.swift; path = Sources/ContentIdentifiable.swift; sourceTree = "<group>"; };
 		90E25634F9115E23F57F339AC8B1A3B9 /* Methods.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Methods.swift; sourceTree = "<group>"; };
-		910BF5CAB2F64C252ED3133D0C7E3AA0 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
-		92433D9F3EF6CCA6F3069239BFDCE84C /* BindableCollection+UIStackView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIStackView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIStackView.swift"; sourceTree = "<group>"; };
-		9286E4E70459FF4031B156D5D2F4D858 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
-		929DC0A856CC06157FC87654231ADBCE /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
-		92E6797C9FFB372179EB33EA9F090E97 /* Dimension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Dimension.swift; path = Draftsman/Classes/Anchors/Defined/Dimension.swift; sourceTree = "<group>"; };
-		93329935943431AA1091E935BAD68EF6 /* Equal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Equal.swift; path = Sources/Nimble/Matchers/Equal.swift; sourceTree = "<group>"; };
-		93AA2D74F75CB85E9BF0FD6835563CEA /* NSLayoutDimension+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSLayoutDimension+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/NSLayoutDimension+Extensions.swift"; sourceTree = "<group>"; };
-		940091854BAF3314743B88BD11043B89 /* XCTestObservationCenter+CurrentTestCaseTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestObservationCenter+CurrentTestCaseTracker.h"; path = "Nimble_Snapshots/XCTestObservationCenter+CurrentTestCaseTracker.h"; sourceTree = "<group>"; };
-		941977223A9A0B4DF269C119C4BFDF1C /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
-		946A0B6964FAE6494BC5951FA0E9913A /* iOSSnapshotTestCase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iOSSnapshotTestCase.debug.xcconfig; sourceTree = "<group>"; };
-		96A598FAB911A90E8FE58B78A829ECDE /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
-		96A621B1EEB47FDD39E44D89BBFD664B /* RootObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootObservable.swift; path = Pharos/Classes/Relay/RootObservable.swift; sourceTree = "<group>"; };
-		974B5B86B45250B3A6D781BD18FD421C /* PlannedDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlannedDraft.swift; path = Draftsman/Classes/Draft/PlannedDraft.swift; sourceTree = "<group>"; };
+		9140C28C0126C157068F8AA51BCBFFBD /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
+		9170A982344457F661E138494928C083 /* Quick.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.release.xcconfig; sourceTree = "<group>"; };
+		9333ABD679D60CE2C93C9573E586E0F2 /* iOSSnapshotTestCase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "iOSSnapshotTestCase-dummy.m"; sourceTree = "<group>"; };
+		95B6C590BDD4780009EAA6D9DA337FDE /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extensions.swift"; path = "Impose/Classes/Dictionary+Extensions.swift"; sourceTree = "<group>"; };
+		95F09C7987A82245AC9D22FCC83983E9 /* UIControlAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIControlAction.swift; path = Pharos/Classes/UIControl/UIControlAction.swift; sourceTree = "<group>"; };
+		966C737E4D26410BBC1A6CAE82B3A4D9 /* Draftsman-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Draftsman-dummy.m"; sourceTree = "<group>"; };
+		96F886AB1120AD45B880AD54B91DD455 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
+		989AABAEE0CC5902F8A5E26BBD7B36A7 /* QuadAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuadAnchor.swift; path = Draftsman/Classes/Anchors/Base/QuadAnchor.swift; sourceTree = "<group>"; };
 		98C2E520DED104F0074F0AFE771088E2 /* Artisan */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Artisan; path = Artisan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		993C9E844CE806EB028E36519B018B27 /* DiffableDataSources-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "DiffableDataSources-Info.plist"; sourceTree = "<group>"; };
-		9A9CE90FD78A4F310C33D2FBD8A69297 /* AxisAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AxisAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/AxisAnchorRelation.swift; sourceTree = "<group>"; };
-		9B6F758F7E96FEB297B9B1029DDCF00E /* ElementsEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementsEqual.swift; path = Sources/Nimble/Matchers/ElementsEqual.swift; sourceTree = "<group>"; };
-		9B98B8CBA5CFF46374EC365AEC200506 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
-		9CAD8FFF3C02E9634A79DBC9F07FE8C1 /* InstanceResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InstanceResolver.swift; path = Impose/Classes/InstanceResolver.swift; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DE62266F808CBFD0D6623A33DFD2A27 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
+		99D243D76B6B0769ECA2A3FFA81AD3DB /* Builder-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Builder-Info.plist"; sourceTree = "<group>"; };
+		9A9B3F5A8D3916FED03F96F0EA8A36DE /* UIImage+Snapshot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Snapshot.m"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.m"; sourceTree = "<group>"; };
+		9AF8BFBA4E507571D049BE7F9A610726 /* Pair.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Pair.swift; path = Draftsman/Classes/Anchors/Defined/Pair.swift; sourceTree = "<group>"; };
+		9CA1D7C7FF0EF8B627F589C33E9090FA /* Draftsman.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Draftsman.modulemap; sourceTree = "<group>"; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9E2354BD3A5A609612C2576D995BA8CF /* Quick.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.debug.xcconfig; sourceTree = "<group>"; };
 		9E5CE8D85A31546DD7762E78B58F14AB /* Artisan-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Artisan-prefix.pch"; sourceTree = "<group>"; };
-		9E9FDD46562F9F6E3E7DA96E32D29012 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickObjCRuntime/QuickSpecBase.m; sourceTree = "<group>"; };
-		9F678919E0FAD0B365E60F42B0CD2307 /* SnapshotStructure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SnapshotStructure.swift; path = Sources/Internal/SnapshotStructure.swift; sourceTree = "<group>"; };
-		9F8C98C269A257389AB4C6E0E29D5221 /* NSLayoutConstraint+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSLayoutConstraint+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/NSLayoutConstraint+Extensions.swift"; sourceTree = "<group>"; };
-		A02B633731AF54640C496A77E303336A /* Chary-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Chary-dummy.m"; sourceTree = "<group>"; };
-		A0A5AB4EAB0E7A99B017DA9E4D740E04 /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
+		9E67858EC04F7B9B2532565C0063852E /* DifferenceKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DifferenceKit.release.xcconfig; sourceTree = "<group>"; };
+		9FBE19E94D69FE1BBD172BB9A5515781 /* BindableCollection+UICollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UICollectionView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UICollectionView.swift"; sourceTree = "<group>"; };
+		9FF77DF15101029DD52CA5FB1BBB233F /* BindableCollection+UIControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIControl.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIControl.swift"; sourceTree = "<group>"; };
 		A14A78ED51B0FACF2D8F697C87B46388 /* Artisan.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Artisan.release.xcconfig; sourceTree = "<group>"; };
-		A1DA37CEA2CFF8889284A1DA7C81F838 /* FBSnapshotTestController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = FBSnapshotTestCase/FBSnapshotTestController.m; sourceTree = "<group>"; };
-		A1DBF26FBAC36C1B04011AFE2E072C52 /* QuickTestObservation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestObservation.swift; path = Sources/Quick/QuickTestObservation.swift; sourceTree = "<group>"; };
-		A1E7D3B6A6164ACEA24310ED4E59FC4C /* Quad.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Quad.swift; path = Draftsman/Classes/Anchors/Defined/Quad.swift; sourceTree = "<group>"; };
-		A251B732798AFC40B71AC9CFFF9C2EEF /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
-		A2BA47B3F570286E6CEF6D0A4EAD3068 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
+		A20FA603F61E844FADA7E97683CA5E17 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
+		A25BF5E500A9E2235FAF79BFEBFAAF2F /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
 		A32C04AA80E5FC203D367AA35162B5AD /* DiffableDataSources */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DiffableDataSources; path = DiffableDataSources.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A3AA5F11B867859F29682198585A3A3C /* Draftsman.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Draftsman.debug.xcconfig; sourceTree = "<group>"; };
-		A490B2F62EC1971152B2AF116E684140 /* FBSnapshotTestController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = FBSnapshotTestCase/FBSnapshotTestController.h; sourceTree = "<group>"; };
-		A4D8166F31C51BE7D7D67BEAFC4D20A0 /* Single.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Single.swift; path = Draftsman/Classes/Anchors/Defined/Single.swift; sourceTree = "<group>"; };
+		A32EF1E24A7F314B050CF9DB5EEFFE62 /* Planned.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Planned.swift; path = Draftsman/Classes/Draft/Planned.swift; sourceTree = "<group>"; };
+		A422D5BB4C544536C7365E1DB3870D85 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
+		A554CAFF68A1670E54D9A208FBEAC439 /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
 		A56566CD8BB44339ECC6137A88191FF5 /* Pods-Artisan_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Artisan_Example.modulemap"; sourceTree = "<group>"; };
-		A5C4EA59F720E9CD8FA617D9D0353564 /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
-		A7F237A74B8BB1E27B08E12C2BDA9B2E /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
-		A8BBE8B87F291B6B5267E9C7B51F55FA /* LayoutWithAnchors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutWithAnchors.swift; path = Draftsman/Classes/Anchors/LayoutWithAnchors.swift; sourceTree = "<group>"; };
-		A8E54C170A37B2E5EDAE907822146532 /* DiffableDataSources.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DiffableDataSources.debug.xcconfig; sourceTree = "<group>"; };
-		A9A41D5250027CDBEBCB776BA9E40264 /* Impose-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Impose-umbrella.h"; sourceTree = "<group>"; };
-		AA0E17F6121AD73BA387D5ECC1267DB6 /* QuickSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpec.m; path = Sources/QuickObjectiveC/QuickSpec.m; sourceTree = "<group>"; };
-		ABA56E0304061E7751A73E9233465F0B /* iOSSnapshotTestCase.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = iOSSnapshotTestCase.modulemap; sourceTree = "<group>"; };
+		A72EC3090B7CA3658DFDD0773F5DDE0A /* Clavier.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Clavier.release.xcconfig; sourceTree = "<group>"; };
+		A8115C8FCE56D8B08764BAFEBF357213 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
+		A872E37B3AC6FF303E2FD94E65FC19AF /* FBSnapshotTestCase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FBSnapshotTestCase.debug.xcconfig; sourceTree = "<group>"; };
+		A8FF02CC4458AFD25F8A0B0713C6F14C /* Axis.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Axis.swift; path = Draftsman/Classes/Anchors/Defined/Axis.swift; sourceTree = "<group>"; };
+		A9195138B9659C5A257AB4C60A9C1352 /* BeLogical.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLogical.swift; path = Sources/Nimble/Matchers/BeLogical.swift; sourceTree = "<group>"; };
+		A9BE7F0C1BCB6D0C892EE6AB25A63660 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
+		AA06165C4EC18EFE4D5624DD11EAE435 /* InjectContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InjectContext.swift; path = Impose/Classes/InjectContext.swift; sourceTree = "<group>"; };
+		AA150DEC94AA33CE21F364C2F0148673 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
+		ABB09A11566CF986AD48C6549F1DF6FE /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
+		ABC4702B8DD851EAA0D60C2C6A2A8EC6 /* Buildable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Buildable.swift; path = Builder/Classes/Buildable.swift; sourceTree = "<group>"; };
+		AC131BCEA2B6B7F4927EB980C0283274 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		AC20B956EC210DAB2CF6F8199575A6E6 /* Atomic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Atomic.swift; path = Chary/Classes/Atomic.swift; sourceTree = "<group>"; };
+		AC521E5EC20BD9EBDCEE402A29B7E1D2 /* Draftsman.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Draftsman.debug.xcconfig; sourceTree = "<group>"; };
 		ACC59B80C78441115E3A7D8F79C8D905 /* Pods-Artisan_Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-Artisan_Tests"; path = Pods_Artisan_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		ADF99BE5AAAFF13F299321082FDA0EB0 /* BindableCollectionCellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BindableCollectionCellView.swift; path = Pharos/Classes/PopulatedRelays/BindableCollectionCellView.swift; sourceTree = "<group>"; };
-		AE80D8868DE00ECEF6E14B6DFBE26FF9 /* Artisan.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = Artisan.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		AEAC6C2E9E92E355963AD626F25304F5 /* SingleAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/SingleAnchorRelation.swift; sourceTree = "<group>"; };
-		AEC0B9A19C9416482F7687FE5B6F50D7 /* BeWithin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeWithin.swift; path = Sources/Nimble/Matchers/BeWithin.swift; sourceTree = "<group>"; };
-		AFF49DF38AA0802F8827B1691C87D4AF /* NBSMockedApplication.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NBSMockedApplication.h; path = Nimble_Snapshots/DynamicType/NBSMockedApplication.h; sourceTree = "<group>"; };
-		AFF97B906871DDA288C4841F5BC888DE /* BindableCollection+UICollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UICollectionView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UICollectionView.swift"; sourceTree = "<group>"; };
-		B008CAA163FB6520E7093797421AFB23 /* AxisAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AxisAnchor.swift; path = Draftsman/Classes/Anchors/Base/AxisAnchor.swift; sourceTree = "<group>"; };
-		B058E81936E33FC8F7675DA75E30323B /* LayoutDraftBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutDraftBuilder.swift; path = Draftsman/Classes/Utilities/LayoutDraftBuilder.swift; sourceTree = "<group>"; };
-		B06E2BE5402C4DED46CE9233092922C1 /* UIImage+Snapshot.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Snapshot.h"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.h"; sourceTree = "<group>"; };
-		B09FFF38275C1AF9EA37D19C8CC0F1C5 /* BindableCollection+UIScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIScrollView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIScrollView.swift"; sourceTree = "<group>"; };
-		B0AE796C235D92E193ECAB844FAEC5D7 /* Clavier.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Clavier.debug.xcconfig; sourceTree = "<group>"; };
-		B1304AEA4C2A29BDFB0FD334F6D37235 /* Clavier-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Clavier-Info.plist"; sourceTree = "<group>"; };
-		B204267D3B8FD83A3EFB617F91FC32DD /* Subject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subject.swift; path = Pharos/Classes/Observable/Subject.swift; sourceTree = "<group>"; };
-		B2156F5872120D784B153AB8C85D2E9E /* SizeAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SizeAnchor.swift; path = Draftsman/Classes/Anchors/Base/SizeAnchor.swift; sourceTree = "<group>"; };
-		B22FC8E5CBDFF2E5987E05D43ED99C14 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
-		B24855FF78369168A881DFF7C4D8694A /* UIKitExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIKitExtension.swift; path = Sources/Extensions/UIKitExtension.swift; sourceTree = "<group>"; };
-		B446FD412422B0711C9D35FE6CDE3F8B /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
+		ADE8FF5F1C49D5792C32803D3505E4F2 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
+		AE502FA68628C7C40494651F4E477BC9 /* TriConstant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TriConstant.swift; path = Draftsman/Classes/Model/TriConstant.swift; sourceTree = "<group>"; };
+		AE5F81D6211CA97CC73304A3C24B3CFD /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCase.m; path = FBSnapshotTestCase/FBSnapshotTestCase.m; sourceTree = "<group>"; };
+		AE80D8868DE00ECEF6E14B6DFBE26FF9 /* Artisan.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = Artisan.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		AEF87C07788E7106769ED61D4BACBE86 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
+		B0E51E0B834287C702C906BAD9CBE9E1 /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCase.h; path = FBSnapshotTestCase/FBSnapshotTestCase.h; sourceTree = "<group>"; };
+		B10869DBD981C089A89A6A64FE9BFE3C /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		B1AEB7CF644CB3D46AAA0A444C99495D /* QCKConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QCKConfiguration.swift; path = Sources/Quick/Configuration/QCKConfiguration.swift; sourceTree = "<group>"; };
+		B340E7679E814ABA2670F1BCD6D63862 /* UIView+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIView+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/UIView+Extensions.swift"; sourceTree = "<group>"; };
+		B3C7A5A04506DCE72EF2E6327823E765 /* Chary.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Chary.modulemap; sourceTree = "<group>"; };
+		B42D68D42B8EE5678A3B39A958F654E9 /* PairAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/PairAnchorRelation.swift; sourceTree = "<group>"; };
+		B46599AE5A0C611FC09CF8438660458D /* SnapshotStructure.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SnapshotStructure.swift; path = Sources/Internal/SnapshotStructure.swift; sourceTree = "<group>"; };
+		B4AD9CD203F70ACB3E195F22431ADE3E /* Chary-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Chary-umbrella.h"; sourceTree = "<group>"; };
 		B4BA0D66243C011B574A5162D6BE6580 /* Pods-Artisan_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Artisan_Example.release.xcconfig"; sourceTree = "<group>"; };
-		B512C78E55A90354D479A1DA348A1184 /* Nimble-Snapshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Nimble-Snapshots.debug.xcconfig"; sourceTree = "<group>"; };
-		B52A1D267E4306D38FBC60311C53596D /* Clavier-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Clavier-dummy.m"; sourceTree = "<group>"; };
-		B6E31FEE7CFC8305CDDFB9951256A420 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = FBSnapshotTestCase/SwiftSupport.swift; sourceTree = "<group>"; };
-		B72EBF0D4023050021F500E9A2D38F8B /* FBSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "FBSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
-		B75B41A005271D4586413F73132419A4 /* Draftsman-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Draftsman-prefix.pch"; sourceTree = "<group>"; };
+		B510E77FFC87218687B479FD7EB92A97 /* UIImage+Diff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Diff.h"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.h"; sourceTree = "<group>"; };
+		B5169441A14DCD184E4FD17B52138545 /* DiffableDataSources-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DiffableDataSources-prefix.pch"; sourceTree = "<group>"; };
+		B552FC5FE0C95E8C842ECA0E352547E2 /* ImposeError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImposeError.swift; path = Impose/Classes/ImposeError.swift; sourceTree = "<group>"; };
+		B56A0F234860DAE5EDB3A1E1A9AC8539 /* Nimble-Snapshots.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Nimble-Snapshots.debug.xcconfig"; sourceTree = "<group>"; };
+		B77A21B9AA97E3109FA1008506D1ABBB /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
+		B7BBB227EDBB7BFA05AC77D1BABA6987 /* AxisAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AxisAnchor.swift; path = Draftsman/Classes/Anchors/Base/AxisAnchor.swift; sourceTree = "<group>"; };
 		B8710B35A5A37D4372FABE6653537450 /* Pods-Artisan_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Artisan_Example-umbrella.h"; sourceTree = "<group>"; };
-		B882EE91D19B7E057370DF90349F0D39 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
-		B89A78F0D4B73383F387FE43B9A8081E /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
+		B8F529B749964D64E300B52A2769199C /* Clavier.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Clavier.debug.xcconfig; sourceTree = "<group>"; };
 		B91B00F8BE943329D633234BD67AE0AC /* iOSSnapshotTestCase */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = iOSSnapshotTestCase; path = FBSnapshotTestCase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BA17DF457CFBD231322647992FBA2C23 /* UIImage+Compare.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Compare.m"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.m"; sourceTree = "<group>"; };
-		BA41A10C24DA040F16E08E2811ECD51B /* Draftsman.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Draftsman.modulemap; sourceTree = "<group>"; };
+		B9FC95A057FAFB6146B3737C52662B5D /* Pharos-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pharos-prefix.pch"; sourceTree = "<group>"; };
 		BAE263041362D074978BB3B577DF0A05 /* Nimble */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BB90DAEB2EAB5974F43734AF4AA73E8B /* PairConstant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairConstant.swift; path = Draftsman/Classes/Model/PairConstant.swift; sourceTree = "<group>"; };
-		BB96A42E6A29814E9993D065AE489B0C /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
-		BBB6922C2FBD9852EE6A94C9D8CADA31 /* ConstraintBuilderRootRecoverable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintBuilderRootRecoverable.swift; path = Draftsman/Classes/Anchors/ConstraintBuilderRootRecoverable.swift; sourceTree = "<group>"; };
-		BC7E005E09BE55303F395B5D9AA51835 /* DiffableDataSources.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DiffableDataSources.release.xcconfig; sourceTree = "<group>"; };
-		BC847D7774E3F23D2B7570E7967F34C4 /* BindableCollection+UIView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIView.swift"; sourceTree = "<group>"; };
-		BCA6812B2408C6D670466B1A95C65396 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
-		BD32D66C8033157D927794F2158927BC /* Draftsman-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Draftsman-dummy.m"; sourceTree = "<group>"; };
-		BDD10CCC395D25CD767B25B745C69822 /* HaveValidDynamicTypeSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveValidDynamicTypeSnapshot.swift; path = Nimble_Snapshots/DynamicType/HaveValidDynamicTypeSnapshot.swift; sourceTree = "<group>"; };
-		BEC878C53567060ED9A38659A3C83CC7 /* StackCompatible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StackCompatible.swift; path = Draftsman/Classes/Utilities/StackCompatible.swift; sourceTree = "<group>"; };
-		BF6D1C3C83ECEB5F19F8EBC10113DE1E /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCase.h; path = FBSnapshotTestCase/FBSnapshotTestCase.h; sourceTree = "<group>"; };
-		C14896559753F34301A2D6B7932C2968 /* UniversalError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UniversalError.swift; path = Sources/Internal/UniversalError.swift; sourceTree = "<group>"; };
-		C18E47C3136CAA8450CF75B91D1BF625 /* BeginWithPrefix.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWithPrefix.swift; path = Sources/Nimble/Matchers/BeginWithPrefix.swift; sourceTree = "<group>"; };
-		C2114A1DC41AF49A90D10FD82496E21F /* SafeAreaKeyboardLayoutGuide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SafeAreaKeyboardLayoutGuide.swift; path = Clavier/Classes/SafeAreaKeyboardLayoutGuide.swift; sourceTree = "<group>"; };
-		C22B0DD847385FFBA9A7D93E318F35A7 /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCase.m; path = FBSnapshotTestCase/FBSnapshotTestCase.m; sourceTree = "<group>"; };
-		C321D660A3A039C92AFF5EC6568C84A4 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
-		C3DDE4C1C61A71B532678AF658A1DF0B /* FilteredObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilteredObservable.swift; path = Pharos/Classes/Relay/FilteredObservable.swift; sourceTree = "<group>"; };
-		C471E1764F3776F488CC7D21C35E30E0 /* BindableCollection+UIButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIButton.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIButton.swift"; sourceTree = "<group>"; };
+		BBA2E6EA286FD3D00055AE11 /* ViewBindable+Retaining.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewBindable+Retaining.swift"; sourceTree = "<group>"; };
+		BBF057DB2871C66F00D34444 /* Observable+Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+Binding.swift"; sourceTree = "<group>"; };
+		BC94E2A5AA0C6DF4F61B60F52D99318C /* ObservableBlock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableBlock.swift; path = Pharos/Classes/Relay/ObservableBlock.swift; sourceTree = "<group>"; };
+		BF0C0D6660D2C3E33BF27FCB8A778D3D /* iOSSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "iOSSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
+		BF61774000E7A82647EA088F8534FE8C /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
+		BF8EEC9238191C52E8003E1A80A8FE63 /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
+		BFED2A450807A45060E592F222CF4FD5 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = FBSnapshotTestCase/SwiftSupport.swift; sourceTree = "<group>"; };
+		C05AB360292FB0C7E7FE977451943CF0 /* ElementsEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementsEqual.swift; path = Sources/Nimble/Matchers/ElementsEqual.swift; sourceTree = "<group>"; };
+		C21BAEB3413ACCE398AB1857021DD512 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
+		C2798D37C3B7A9B9B72904ECECBADCAE /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCasePlatform.h; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
+		C2A12BEA6A42BE446EED9D1986872C6E /* Nimble.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.release.xcconfig; sourceTree = "<group>"; };
+		C4A3A9585BA13997F71FD9AD9D380431 /* ConstraintBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintBuilder.swift; path = Draftsman/Classes/Utilities/ConstraintBuilder.swift; sourceTree = "<group>"; };
 		C4FFDEE39A327160E6D951BFB3C7BDD0 /* Array+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		C562EEC818D23D9005E9D7208B689085 /* Cell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
-		C5C7F9616050C2986E479A4B1D24AD07 /* NBSMockedApplication.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NBSMockedApplication.m; path = Nimble_Snapshots/DynamicType/NBSMockedApplication.m; sourceTree = "<group>"; };
 		C5FB2F9BF0AD9E9C05F9C98CBA51D9B5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		C61E47D6447772A0396A8C2FAEBE597C /* UIImage+Compare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "FBSnapshotTestCase/Categories/UIImage+Compare.h"; sourceTree = "<group>"; };
-		C6F53C998FB56DF28EC9D4E0228A4C06 /* Nimble-Snapshots-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-Snapshots-umbrella.h"; sourceTree = "<group>"; };
-		C76D9AE56C626B883BDA291D632DE065 /* ResolverFunction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResolverFunction.swift; path = Impose/Classes/ResolverFunction.swift; sourceTree = "<group>"; };
-		C778224F6D17526D332A1A732D62F6C3 /* iOSSnapshotTestCase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iOSSnapshotTestCase-prefix.pch"; sourceTree = "<group>"; };
-		C7984627147E649F201C684CB5CDCFFA /* BuilderConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuilderConfig.swift; path = Builder/Classes/BuilderConfig.swift; sourceTree = "<group>"; };
+		C6174C9B77403AE99CA3044A42A8EC81 /* BindableCollection+UISlider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UISlider.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UISlider.swift"; sourceTree = "<group>"; };
+		C63FD177C37DDAFDC697F400A9310B45 /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		C7B99FB5C27E6ABFBDE288D89C281A6D /* Draftsman.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Draftsman.release.xcconfig; sourceTree = "<group>"; };
 		C828269CB8357869E8D0FD7249922375 /* Artisan.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Artisan.modulemap; sourceTree = "<group>"; };
+		C83519F8C3F54501C46543D40A68A3CF /* iOSSnapshotTestCase.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = iOSSnapshotTestCase.modulemap; sourceTree = "<group>"; };
+		C8362060E458F5BFC4BDF7249605B707 /* QuickTestObservation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickTestObservation.swift; path = Sources/Quick/QuickTestObservation.swift; sourceTree = "<group>"; };
+		C84001CBA62A9367004CD433B640DD2C /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
+		C87B24A186FCDB02CF0D595F18D832BC /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
 		C94918E91CBA2E9CA0C34659AB6BA21E /* Maker+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Maker+Extensions.swift"; sourceTree = "<group>"; };
-		C94973BE36813745D40773DEF1E94862 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
-		C9ECB446D9734A1F12F219FF998C329A /* Impose.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Impose.modulemap; sourceTree = "<group>"; };
-		CA8378862E5657D3E81B13FA3E9FB998 /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
-		CAD901917E019C8ABD4A7789A1CF13F4 /* Equal+Tuple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Equal+Tuple.swift"; path = "Sources/Nimble/Matchers/Equal+Tuple.swift"; sourceTree = "<group>"; };
-		CBA89870AA9EAE8927914B63A7CA1C79 /* FBSnapshotTestController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = FBSnapshotTestCase/FBSnapshotTestController.h; sourceTree = "<group>"; };
-		CCE3261E81F79A0F2C33E995E3ABFAE0 /* Nimble.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.release.xcconfig; sourceTree = "<group>"; };
+		CA2D2533E4A629D636BF9B8287DC344C /* LayoutDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutDraft.swift; path = Draftsman/Classes/Draft/LayoutDraft.swift; sourceTree = "<group>"; };
+		CA9A656426259B3441D2BA08A88EF2AE /* RelayInvoker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RelayInvoker.swift; path = Pharos/Classes/Utils/RelayInvoker.swift; sourceTree = "<group>"; };
+		CAB672C174FDDB9C34E15D27F97579B1 /* ClavierLayoutGuide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClavierLayoutGuide.swift; path = Clavier/Classes/ClavierLayoutGuide.swift; sourceTree = "<group>"; };
+		CB52DE9A16B2B47581B7590E64B8F1D4 /* UIImage+Snapshot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Snapshot.m"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.m"; sourceTree = "<group>"; };
+		CB97CEF87923E8ACD3BCCFE9CC952D2B /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCasePlatform.h; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
+		CC6229B0CD8E96ED8F76C41BFA7BAE3F /* Retainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Retainer.swift; path = Pharos/Classes/Model/Retainer.swift; sourceTree = "<group>"; };
 		CCF7B3BCCB90A6C28C29ABFDEF6ED19D /* Pods-Artisan_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Artisan_Example-dummy.m"; sourceTree = "<group>"; };
-		CDB0343BE61468CA36A4E2E5B95B018C /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCasePlatform.m; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
-		CDC23B594EF5A767ED37B2994819B304 /* Pharos-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pharos-prefix.pch"; sourceTree = "<group>"; };
-		D01952EFDB1C5D32DBA15CD6044CF0F5 /* Impose-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Impose-Info.plist"; sourceTree = "<group>"; };
-		D0AE7FB63803E68997653B97A558AC58 /* iOSSnapshotTestCase-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iOSSnapshotTestCase-umbrella.h"; sourceTree = "<group>"; };
-		D0B8D6B4BB1FC7844650895AFA34C70C /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extensions.swift"; path = "Pharos/Classes/Utils/Dictionary+Extensions.swift"; sourceTree = "<group>"; };
-		D1E43DF8882DC7045E549106933310FC /* Scopable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scopable.swift; path = Impose/Classes/Scopable.swift; sourceTree = "<group>"; };
-		D4A68C7DF5D05CE684BAA1B3B6C7B982 /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
+		CD038515EE39DB69BA1B155638B8190F /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
+		CD03B9F6E829B557161728E1637C345E /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
+		CD86455E3384C9970EA0E4997A45A3B0 /* FBSnapshotTestCase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FBSnapshotTestCase-dummy.m"; sourceTree = "<group>"; };
+		CE0AA3CA9258952746C5046535F3B4C8 /* Draftsman-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Draftsman-Info.plist"; sourceTree = "<group>"; };
+		CE60D8EED0C1A735B7454F76E9F57FE0 /* BeWithin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeWithin.swift; path = Sources/Nimble/Matchers/BeWithin.swift; sourceTree = "<group>"; };
+		CFF2C29F96615B40A37A0CD796794FA8 /* ContentEquatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentEquatable.swift; path = Sources/ContentEquatable.swift; sourceTree = "<group>"; };
+		D0427D7265C12F833F973F27314FAD4A /* TableViewDiffableDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TableViewDiffableDataSource.swift; path = Sources/UIKit/TableViewDiffableDataSource.swift; sourceTree = "<group>"; };
+		D0492BCE3BF1DBBEE3F866286D283E0D /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
+		D08734FE82D4DFBBA5AE8FF59A8DAF35 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
+		D0A251C16525E043B5843A049F091676 /* Nimble-Snapshots-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-Snapshots-umbrella.h"; sourceTree = "<group>"; };
+		D11D5FE18BA090E3D202EF3D5B43DF68 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
+		D1971CB2689FE21A1FF0F6ABED696EEE /* FBSnapshotTestCase-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FBSnapshotTestCase-umbrella.h"; sourceTree = "<group>"; };
+		D2055F787F1ED2C488492A76AC2ED170 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
+		D31086BA04FDF4933C31013C7FC9EC2B /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Dictionary+Extensions.swift"; path = "Pharos/Classes/Utils/Dictionary+Extensions.swift"; sourceTree = "<group>"; };
+		D31AEA7BA2234939049F20CB527268B2 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
+		D347FF5DDE93935EB0D9AC2A16B1FD25 /* Builder-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Builder-umbrella.h"; sourceTree = "<group>"; };
+		D3D9073747974921B39E2860CB14DA4A /* Await.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Await.swift; path = Sources/Nimble/Utils/Await.swift; sourceTree = "<group>"; };
+		D43BFE8393EFD717CB3E59EA90EAD967 /* QuickObjCRuntime.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickObjCRuntime.h; path = Sources/QuickObjCRuntime/include/QuickObjCRuntime.h; sourceTree = "<group>"; };
+		D4557AA2B890C3D688C60A4F36B1A2F8 /* FBSnapshotTestController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = FBSnapshotTestCase/FBSnapshotTestController.m; sourceTree = "<group>"; };
+		D4648DBA99775EDEE965856D13AE52A8 /* DiffableDataSourceSnapshot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DiffableDataSourceSnapshot.swift; path = Sources/DiffableDataSourceSnapshot.swift; sourceTree = "<group>"; };
+		D4BB5A352F71AA65CF099E08BE7E4A8E /* ViewPlanBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewPlanBuilder.swift; path = Draftsman/Classes/Draft/ViewPlanBuilder.swift; sourceTree = "<group>"; };
+		D561B067E876E7BE7C6A544A3D2873DB /* LayoutWithAnchors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutWithAnchors.swift; path = Draftsman/Classes/Anchors/LayoutWithAnchors.swift; sourceTree = "<group>"; };
+		D5AE692E2EB0B0AEFEAAED8B489EA021 /* XCTestObservationCenter+CurrentTestCaseTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+CurrentTestCaseTracker.m"; path = "Nimble_Snapshots/XCTestObservationCenter+CurrentTestCaseTracker.m"; sourceTree = "<group>"; };
 		D69604901D33E9B6FA694B0F51C0E928 /* UIView+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
-		DABDA0FD6F2E305012326F8CEE10D76A /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCasePlatform.h; path = FBSnapshotTestCase/FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
-		DAC074DF26EB98CE65AC54A0CC6AFC70 /* Nimble-Snapshots-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Snapshots-Info.plist"; sourceTree = "<group>"; };
-		DBED13A3083A6AA931656CFC54ED3917 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = FBSnapshotTestCase/SwiftSupport.swift; sourceTree = "<group>"; };
-		DBFABBF7638B2D98E38AF38BA19C7D4E /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		D7BDCDB2DEA5D5770412DD6711C714CE /* UIImage+Diff.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Diff.m"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.m"; sourceTree = "<group>"; };
+		D8E4A020A29A84C2D3F5D020D8F912C3 /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
+		D924A3A8B68F65410643D92C4DA11140 /* Pharos.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pharos.debug.xcconfig; sourceTree = "<group>"; };
+		D9C04209E3093D861761CD3BCE9259C1 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
+		DB08AC89A4D792FE11A42B075CCB7B02 /* Dimension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Dimension.swift; path = Draftsman/Classes/Anchors/Defined/Dimension.swift; sourceTree = "<group>"; };
+		DB4AFA40F5765F599F01498E9CB7A35C /* XCTestObservationCenter+CurrentTestCaseTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestObservationCenter+CurrentTestCaseTracker.h"; path = "Nimble_Snapshots/XCTestObservationCenter+CurrentTestCaseTracker.h"; sourceTree = "<group>"; };
 		DC1FD9458005F1B0A61C10F6F295E60E /* ArrayBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArrayBuilder.swift; sourceTree = "<group>"; };
-		DC731D84A2034B1FA6A066DF0C92A65C /* PlanContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlanContext.swift; path = Draftsman/Classes/Draft/PlanContext.swift; sourceTree = "<group>"; };
-		DCA253C6F893C7247603F0FCD2CE3586 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
-		DD11EE05746340EA381D5D32DB6D96CB /* UIImage+Snapshot.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Snapshot.m"; path = "FBSnapshotTestCase/Categories/UIImage+Snapshot.m"; sourceTree = "<group>"; };
-		DE04C7FB4214A8F79CAA22CE977D225B /* Buildable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Buildable.swift; path = Builder/Classes/Buildable.swift; sourceTree = "<group>"; };
-		DF7FDCE302C82F7EC931F92909B1002E /* QuickConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickConfiguration.swift; path = Sources/Quick/Configuration/QuickConfiguration.swift; sourceTree = "<group>"; };
-		DF8474C5E95F98A5EF474612071F7087 /* UIImage+Diff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Diff.h"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.h"; sourceTree = "<group>"; };
-		E029DF35EBE516108FDF15D219ECFD9F /* BindableCollection+UIControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIControl.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIControl.swift"; sourceTree = "<group>"; };
-		E02F56E32697B6FE0C57E60EA9A0D058 /* LayoutAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutAnchor.swift; path = Draftsman/Classes/Anchors/LayoutAnchor.swift; sourceTree = "<group>"; };
-		E1C2655283A979119409EFA45B5BA703 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
-		E330D5BF283B58CF1B35AF6E8225AB70 /* Clavier-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Clavier-prefix.pch"; sourceTree = "<group>"; };
+		DDDEFBBE383CEF0113F6862E05191F60 /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
+		DE54E2C190061D03BECB93BB05655AB3 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		DFBBCE1557736117F9087022832E70CE /* MergedObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MergedObservable.swift; path = Pharos/Classes/Relay/MergedObservable.swift; sourceTree = "<group>"; };
+		E07757421D9121B05540B0D45F20EA93 /* DifferenceKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DifferenceKit-prefix.pch"; sourceTree = "<group>"; };
+		E07F54E35250ED85E929AC5EFAE40F44 /* PrettyDynamicTypeSyntax.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrettyDynamicTypeSyntax.swift; path = Nimble_Snapshots/DynamicType/PrettyDynamicTypeSyntax.swift; sourceTree = "<group>"; };
+		E16DA6F75AD70A35F08DEE2351413D20 /* InstanceResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InstanceResolver.swift; path = Impose/Classes/InstanceResolver.swift; sourceTree = "<group>"; };
+		E17A5AEC3E5916CE23EE63AEC5B80820 /* Impose.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Impose.modulemap; sourceTree = "<group>"; };
+		E17DCC147768DED6F51EC2B5D62D195E /* BindableCollection+UIView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIView.swift"; sourceTree = "<group>"; };
+		E1CF1B093537F4DBAFF5A7D31F69C209 /* PopulatedRelays.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PopulatedRelays.swift; path = Pharos/Classes/PopulatedRelays/PopulatedRelays.swift; sourceTree = "<group>"; };
+		E40276C1791F702619BC497A310435C5 /* BaseProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseProtocols.swift; path = Pharos/Classes/Relay/BaseProtocols.swift; sourceTree = "<group>"; };
+		E42A9BE4B19FCB4CE576B7396BFC5C08 /* Nimble-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Nimble-Info.plist"; sourceTree = "<group>"; };
+		E42F520E0364DEFA6D20F0D1B2139958 /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCase.h; path = FBSnapshotTestCase/FBSnapshotTestCase.h; sourceTree = "<group>"; };
+		E4BEFEEF45D922E53EC7E9A20A2A7432 /* DiffableDataSourceCore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DiffableDataSourceCore.swift; path = Sources/Internal/DiffableDataSourceCore.swift; sourceTree = "<group>"; };
+		E4CADB8F3B95641242DC1BBD53A279FD /* BuilderConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuilderConfig.swift; path = Builder/Classes/BuilderConfig.swift; sourceTree = "<group>"; };
 		E4D0590D7EBC02F63139D10864C42A74 /* Pods-Artisan_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Artisan_Tests-dummy.m"; sourceTree = "<group>"; };
-		E562708482BF2EB6CEDE447CACD70964 /* BindableObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BindableObservable.swift; path = Pharos/Classes/Relay/BindableObservable.swift; sourceTree = "<group>"; };
-		E5C23D4845530804A03AF0BFC7F3470B /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
-		E6345CAC4261F3B0CCC919B0A608CC2E /* Changes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Changes.swift; path = Pharos/Classes/Model/Changes.swift; sourceTree = "<group>"; };
-		E88A4C15CFF2BB4D4B235F25F00A4448 /* PrioritizedAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrioritizedAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/PrioritizedAnchorRelation.swift; sourceTree = "<group>"; };
-		E8E45DEFD541A174D2203936603A261A /* QuadAnchorRelation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuadAnchorRelation.swift; path = Draftsman/Classes/Anchors/Relation/QuadAnchorRelation.swift; sourceTree = "<group>"; };
-		E8E9ABE261BA9648CC5D6A16CC92AA80 /* Quick-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Quick-Info.plist"; sourceTree = "<group>"; };
-		E9738AE1D34A7973355B68F98B6E3702 /* Builder-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Builder-Info.plist"; sourceTree = "<group>"; };
+		E4E197AE0F4FD3E9A3C44B1AF8AE1FC3 /* PlanContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlanContext.swift; path = Draftsman/Classes/Draft/PlanContext.swift; sourceTree = "<group>"; };
+		E5150628D0C3DDF4CE1EDDBE64810EF1 /* Changeset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Changeset.swift; path = Sources/Changeset.swift; sourceTree = "<group>"; };
+		E6C1AA4976F684F9222D4FCC6D92820A /* BindableCollection+UIStepper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UIStepper.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UIStepper.swift"; sourceTree = "<group>"; };
+		E767CD536D9E2EDF469D1D30C0116D22 /* Clavier-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Clavier-dummy.m"; sourceTree = "<group>"; };
+		E8FC9766B25F6F3ED1E0A7512AF6E8D1 /* iOSSnapshotTestCase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = iOSSnapshotTestCase.debug.xcconfig; sourceTree = "<group>"; };
+		E969AB5B1BAA38DC9DDCC42393F1B3B7 /* DifferentiableSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DifferentiableSection.swift; path = Sources/DifferentiableSection.swift; sourceTree = "<group>"; };
+		E969ED978719FCE351F985AF4944D1B5 /* DiffableDataSources.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = DiffableDataSources.release.xcconfig; sourceTree = "<group>"; };
 		E9B7EFB84A0F1F889AA86591E076C9CC /* Pharos */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pharos; path = Pharos.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E9E8062690C092BDCDE2886F0200656A /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCase.h; path = FBSnapshotTestCase/FBSnapshotTestCase.h; sourceTree = "<group>"; };
-		EAE3ECC13C5B9B6D608F1D3C4D12FA97 /* Pharos.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pharos.debug.xcconfig; sourceTree = "<group>"; };
-		EAEEA9C8039CC76007D04EF53BCFC43E /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
-		EB938A476F8019D4D145BC31AE3E614C /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
-		EBA7CFBA8461236442A0AF5BBE8436CE /* Changeset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Changeset.swift; path = Sources/Changeset.swift; sourceTree = "<group>"; };
-		EC2C6761019AFE9AA0076456D8E101B3 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
-		EC492BC359B3FBBB1C4C190B284F8FE0 /* UIKit+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIKit+Extensions.swift"; path = "Draftsman/Classes/Utilities/Extensions/UIKit+Extensions.swift"; sourceTree = "<group>"; };
-		EC7230FB75733E08AAC833628D32E2CA /* Chary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Chary-prefix.pch"; sourceTree = "<group>"; };
-		EDA1545D363F12D38D1BD95005098390 /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
+		EA4FDA7E7C2D315873F35637ACF652BF /* BeGreaterThanOrEqualTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThanOrEqualTo.swift; path = Sources/Nimble/Matchers/BeGreaterThanOrEqualTo.swift; sourceTree = "<group>"; };
+		EA849E7083368971A58B897F06ECF4FB /* LayoutAxisAnchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutAxisAnchor.swift; path = Draftsman/Classes/Anchors/LayoutAxisAnchor.swift; sourceTree = "<group>"; };
+		EB124C4D47C4B109D574BA2CCBF3657F /* TypeHashable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TypeHashable.swift; path = Impose/Classes/TypeHashable.swift; sourceTree = "<group>"; };
+		EC08D7E26C1209B407C76A391724D1D9 /* ResolverFunction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResolverFunction.swift; path = Impose/Classes/ResolverFunction.swift; sourceTree = "<group>"; };
+		ECEF1543CB3BCCDC444748BD51670C4B /* Impose-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Impose-prefix.pch"; sourceTree = "<group>"; };
+		ED69060AD03A2693E157EAE1FE9C9FD9 /* Impose-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Impose-dummy.m"; sourceTree = "<group>"; };
 		EE3A939C4F760E9CE89442A4A2FBF0FF /* Pods-Artisan_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Artisan_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
+		EECE95321F63A2E957E29B7045E2FADC /* Mirror+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Mirror+Extensions.swift"; path = "Impose/Classes/Mirror+Extensions.swift"; sourceTree = "<group>"; };
 		EEE48FE9B9DC9D4236470F0914BFCDA2 /* Pods-Artisan_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Artisan_Example-frameworks.sh"; sourceTree = "<group>"; };
 		EF0C40D63A5C3218E2FAEAB993CA9879 /* Impose */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Impose; path = Impose.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EF4BFE980117902700C14D371B047753 /* Chary.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Chary.release.xcconfig; sourceTree = "<group>"; };
-		EFAD07ED4D9C4D337A37AD812B7192F7 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CurrentTestCaseTracker.swift; path = Nimble_Snapshots/CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
-		F0B25CDE8AA99BF58EF8602FC867699A /* AnyDifferentiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyDifferentiable.swift; path = Sources/AnyDifferentiable.swift; sourceTree = "<group>"; };
-		F153ECF4DEE5575D636C2B522BB6478E /* Axis.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Axis.swift; path = Draftsman/Classes/Anchors/Defined/Axis.swift; sourceTree = "<group>"; };
+		F0C90DCAD2ECBAAD0BD5AE144863BC0C /* RootObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootObservable.swift; path = Pharos/Classes/Relay/RootObservable.swift; sourceTree = "<group>"; };
+		F1A7BCB53C87F305F3ECBAF24B5C860A /* UIControlSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIControlSubject.swift; path = Pharos/Classes/UIControl/UIControlSubject.swift; sourceTree = "<group>"; };
 		F1CCE42A69837A23C090F29AD42755F7 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		F22AF64DC2D88452F9112FBEF6160703 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Sources/QuickObjectiveC/DSL/QCKDSL.m; sourceTree = "<group>"; };
-		F2484281E8798BEB07CCB1F592A21BF8 /* ClavierLayoutGuide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClavierLayoutGuide.swift; path = Clavier/Classes/ClavierLayoutGuide.swift; sourceTree = "<group>"; };
-		F26A592169A3D35FB26EBA578DBB0198 /* Chary-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Chary-umbrella.h"; sourceTree = "<group>"; };
+		F2966097444B6FDBDAB00AE88274B640 /* PairConstant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PairConstant.swift; path = Draftsman/Classes/Model/PairConstant.swift; sourceTree = "<group>"; };
+		F309142BD044D3A3EB694AE997AD8D54 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickObjCRuntime/include/QuickSpecBase.h; sourceTree = "<group>"; };
 		F3170C09D1A96A0DBE5301A493BF0E2D /* Pods-Artisan_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Artisan_Tests.modulemap"; sourceTree = "<group>"; };
-		F338F1E4E9E61ABB15C513F6AC4B772A /* Injector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Injector.swift; path = Impose/Classes/Injector.swift; sourceTree = "<group>"; };
-		F5871F2D8BD5FA7A8F36D8D1E00C3919 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Extensions.swift"; path = "Chary/Classes/DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
-		F5ADABE308A64D70FC62D843CBEFD7FB /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Quick.modulemap; sourceTree = "<group>"; };
-		F679F3EBCD348BA01CD5ED5479CEF1F5 /* DifferenceKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DifferenceKit-prefix.pch"; sourceTree = "<group>"; };
-		F7279BFE3593C038F922B8075BC930FD /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
-		F768E9892B131E387E44F7738969EE69 /* Chary.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Chary.modulemap; sourceTree = "<group>"; };
-		F86F8711879153EC95FB09F62D41F0DF /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
-		F9408342CC9ECC49567A9B4ECACB23BA /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
-		F9AD8F885C2D2573BE89E22A8E0944B7 /* BindableCollection+UITableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BindableCollection+UITableView.swift"; path = "Pharos/Classes/PopulatedRelays/BindableCollection+UITableView.swift"; sourceTree = "<group>"; };
-		FA02F9EAD65B3866B7E6D0F4B770F39F /* MainThreadSerialDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainThreadSerialDispatcher.swift; path = Sources/Internal/MainThreadSerialDispatcher.swift; sourceTree = "<group>"; };
-		FBD6ADF6F2F09EE90046BA1AB6907512 /* Builder.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Builder.release.xcconfig; sourceTree = "<group>"; };
-		FC6CF17F617DC7102A35F55E3C0E42CC /* LayoutDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutDraft.swift; path = Draftsman/Classes/Draft/LayoutDraft.swift; sourceTree = "<group>"; };
-		FCC3E6EF36C612C433233DEA6F14132A /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
-		FD598A36158E3DB804D282D879DDBDA0 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
-		FDF15EEAAB47AC41015F3959F43DAF18 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
-		FE22E1954325C34D83FEAB162FACF4F1 /* DifferenceKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "DifferenceKit-umbrella.h"; sourceTree = "<group>"; };
-		FF239F2678DC67F57B9EFE59DF6CA32B /* UIImage+Diff.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Diff.m"; path = "FBSnapshotTestCase/Categories/UIImage+Diff.m"; sourceTree = "<group>"; };
-		FF30E9C5AEB4917A133334A432B35F3E /* Publisher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Publisher.swift; path = Pharos/Classes/Relay/Publisher.swift; sourceTree = "<group>"; };
-		FF7F6290AF422BA8B8735CE1A1E8EDB2 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickObjCRuntime/include/QuickSpecBase.h; sourceTree = "<group>"; };
-		FFB70EC31BF10704DE935C13FC7E6791 /* Nimble-Snapshots.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Nimble-Snapshots.modulemap"; sourceTree = "<group>"; };
-		FFC3AD31675EC3ED4DA43C1F45048076 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		F405A3F6D012E6C95F68E02361A857F3 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
+		F462465104147BB4A144BC12AB4056D5 /* iOSSnapshotTestCase-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iOSSnapshotTestCase-umbrella.h"; sourceTree = "<group>"; };
+		F4B6A6775A20D152B793ABE6068A8011 /* Trio.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Trio.swift; path = Draftsman/Classes/Anchors/Defined/Trio.swift; sourceTree = "<group>"; };
+		F4E83BC7353540CCD32305C6D5C33455 /* Nimble-Snapshots-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-Snapshots-dummy.m"; sourceTree = "<group>"; };
+		F541104E82B4BE54EE77FE77A2BA07EB /* StagedChangeset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StagedChangeset.swift; path = Sources/StagedChangeset.swift; sourceTree = "<group>"; };
+		F59850663F6808953A081C401EE7FC99 /* PlannedDraft.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlannedDraft.swift; path = Draftsman/Classes/Draft/PlannedDraft.swift; sourceTree = "<group>"; };
+		F5AC65036D6E9A84860DDA4629635668 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
+		F5FCA74EC5519B8C0B122E0EFA9C4AA8 /* Impose-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Impose-umbrella.h"; sourceTree = "<group>"; };
+		F782AB11AD5E9B56FD9A59B972E00D65 /* Chary.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Chary.release.xcconfig; sourceTree = "<group>"; };
+		F7D1A0301AB1FF9F81B9B0A8E6A35089 /* DiffableDataSources-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "DiffableDataSources-Info.plist"; sourceTree = "<group>"; };
+		F8FA4E0DFD336AB01E9201A729A56095 /* BeResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeResult.swift; path = Sources/Nimble/Matchers/BeResult.swift; sourceTree = "<group>"; };
+		FA194F10DB279BD3B8900C5EB29D3C57 /* Nimble_Snapshots.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble_Snapshots.h; path = Nimble_Snapshots/Nimble_Snapshots.h; sourceTree = "<group>"; };
+		FA68554A5324FF8F9851DA897B8539F2 /* Clavier.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Clavier.modulemap; sourceTree = "<group>"; };
+		FB0251F36EC4506C3F07058D0347A9C0 /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Matchers/Async.swift; sourceTree = "<group>"; };
+		FB58ECE7C4CFB36B862F312B86184DB8 /* iOSSnapshotTestCase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iOSSnapshotTestCase-prefix.pch"; sourceTree = "<group>"; };
+		FB82ECD0B5EFF8BFB731AAB2886E6BD6 /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
+		FC626DACEF42BFBBE329407F595188A5 /* Clavier-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Clavier-umbrella.h"; sourceTree = "<group>"; };
+		FD450F904AA2B25734A4684283C2031B /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
+		FDCA813B7968AFC1A0F558B7FAA98240 /* DispatchTimeInterval.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DispatchTimeInterval.swift; path = Sources/Nimble/Utils/DispatchTimeInterval.swift; sourceTree = "<group>"; };
+		FDE99C0F93E1817DE7EF37940FDD5866 /* DifferenceKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = DifferenceKit.modulemap; sourceTree = "<group>"; };
+		FE3FC4820041E5540F1732B57CC78631 /* DifferenceKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "DifferenceKit-Info.plist"; sourceTree = "<group>"; };
+		FE6395A7FC62F1F43D388A1E50BEC558 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		FE992045BC959155A2E98F8F50E08AE4 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickObjCRuntime/QuickSpecBase.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		07BD1411575C5FF2BA02A4C3AC08F8AF /* Frameworks */ = {
+		016E6AD32F91DE08EE13F320848C2CA2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0240801B9D73582505BE11E5F57B8851 /* Foundation.framework in Frameworks */,
+				8571797ED9A7144EDC496ABD61FF0A79 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		24B2B92D592F46D7821FCFB918D6D2B8 /* Frameworks */ = {
+		27C7239029E8ABC8A3AE7B993549F1C9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				036D95FA11B861BF957FD1B24BA6645C /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3B5EF4C1572DD270B74E93C3DB0776B6 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E875BEC7D7EFB87589068F4D0739BB52 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3D49B5F839F172F7F777E688B03A83D2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				613B317E1F2C2044C30389A46CFB2034 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		42085866F9B787834A893F15D17CC58F /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E2F3B26D370E3D05964FF9975F1CE2BB /* Foundation.framework in Frameworks */,
-				544525E7AB35880EE5B156B7359766D5 /* QuartzCore.framework in Frameworks */,
-				EA66E4915561796193A53B0C84A51169 /* UIKit.framework in Frameworks */,
-				2328D1D8D060309CD48C30DF2C08D254 /* XCTest.framework in Frameworks */,
+				93EBD157714466DBCA14EC4E6B3C5283 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -996,15 +979,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				6AED7F323A6E3EA02AE5A29EF248380A /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		613100E04C39CCCE79287D635FF8EFB7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E0939C4B62B7B7983A21254E1F2D776C /* Foundation.framework in Frameworks */,
-				DE8992A898293C55054ECB9458DC1221 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1018,11 +992,12 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7BC9AD4AA92A00DD4BA109C62529B3C8 /* Frameworks */ = {
+		97E4860462D3B341271EF605DDE42A83 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AFBE2FD05E98C4D0967FA59E975A1CA9 /* Foundation.framework in Frameworks */,
+				9FCF4616FCE54CD76D49EF0722DA5A8F /* Foundation.framework in Frameworks */,
+				88E10D0804EC18528E1BB24196179261 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1034,6 +1009,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A43E82E45E34A3CC43778BAAEC650E14 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A0559DC11F6F122B11E16BE791349E67 /* Foundation.framework in Frameworks */,
+				7A1AA2790BA2E012212CF1B917980E3B /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BD5FF9FF298502607702C1B4D7E30630 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1042,12 +1026,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BF10931469DAF8D693EF6781FDD83254 /* Frameworks */ = {
+		BD7B51ED06C47FC6FC80B67286EA8B38 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8C95DB320ACF935831507B6E5EAAB701 /* Foundation.framework in Frameworks */,
-				C989A20A8867701030281222989034E0 /* UIKit.framework in Frameworks */,
+				0008736FDE0C107143F49A74024EA27D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1056,6 +1039,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				7F5D0D3F6CC5E09BD0DB9518F8F10474 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D5705338E523DC84F3BBF86E03B6E7EC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24301FEE7601CD2C0AFC4778010D985E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1087,51 +1078,114 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E54B861B69C914F2CA365135A650C184 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				831C50E61E435828A085DCC5C2308F51 /* Foundation.framework in Frameworks */,
+				ACA4D897EA1620347797A65EC3D479B8 /* QuartzCore.framework in Frameworks */,
+				FBAFD3A6BA0D1B66DAF1649F5D128D78 /* UIKit.framework in Frameworks */,
+				57804A62E51146B84086A85A386C15BE /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F20C10D9C2A9819069790D6A2FC66A21 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46DC7749C1A96AE7405F7E59F6A2E290 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		01D5356265A19D5F4E3EB04741D07DED /* SwiftSupport */ = {
+		0021D78F2D7BBA978AC7D6013A8EC6F3 /* FBSnapshotTestCase */ = {
 			isa = PBXGroup;
 			children = (
-				DBED13A3083A6AA931656CFC54ED3917 /* SwiftSupport.swift */,
+				AACDE9C8C5A4EE5FE5782297ACE4CB6C /* Core */,
+				C927007CB61F17B83889BB80746C2145 /* Support Files */,
+				E563CF4F0E2F1D90F2D511AE4333D51F /* SwiftSupport */,
 			);
-			name = SwiftSupport;
+			path = FBSnapshotTestCase;
 			sourceTree = "<group>";
 		};
-		0E041F3E3BA49110691E6BBE783EF036 /* Support Files */ = {
+		03F60A65A2A7580EEC75BD453CCD2DDE /* Nimble-Snapshots */ = {
 			isa = PBXGroup;
 			children = (
-				1CA73F04757ACE23537A702E730059DF /* Nimble.modulemap */,
-				A2BA47B3F570286E6CEF6D0A4EAD3068 /* Nimble-dummy.m */,
-				714A3DFFC439A48E1389C9951C917675 /* Nimble-Info.plist */,
-				1C27FB4A563905C377EBD921DC727B0A /* Nimble-prefix.pch */,
-				EC2C6761019AFE9AA0076456D8E101B3 /* Nimble-umbrella.h */,
-				53C80243E51F301DB348092DB75C211C /* Nimble.debug.xcconfig */,
-				CCE3261E81F79A0F2C33E995E3ABFAE0 /* Nimble.release.xcconfig */,
+				22F3A1B01D30421DA66024AB8C42A13B /* Core */,
+				D253880E53498D7C7E1F1B44B0890D27 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/Nimble";
+			path = "Nimble-Snapshots";
 			sourceTree = "<group>";
 		};
-		15B15ED6ABC465F993B6283F2ED50F93 /* Impose */ = {
+		0A1FADD1BEFF11C1937F3A171DFA50CE /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				6D36A7DA4746275C769F85C62F1C1C18 /* Dictionary+Extensions.swift */,
-				4C5E9E3B03D1A8AAA9222E50F3F5C893 /* ImposeError.swift */,
-				230D8ED669AC0AA65B645BCEC992B8E5 /* ImposerCompat.swift */,
-				140195E1A681EB716339B07AD26AC7DF /* InjectContext.swift */,
-				F338F1E4E9E61ABB15C513F6AC4B772A /* Injector.swift */,
-				9CAD8FFF3C02E9634A79DBC9F07FE8C1 /* InstanceResolver.swift */,
-				6927E9BF13E65861749978D859C967E2 /* Mirror+Extensions.swift */,
-				3486F5ED3D237FD3828F0EF25E658696 /* ModuleProvider.swift */,
-				85E8621C5B92ACE1CFE113E2F824881E /* PropertyWrapper.swift */,
-				C76D9AE56C626B883BDA291D632DE065 /* ResolverFunction.swift */,
-				D1E43DF8882DC7045E549106933310FC /* Scopable.swift */,
-				6F7EDFC4395005DE3CFC31334A4AB40D /* TypeHashable.swift */,
-				CE90DE7BF83879D43716540DCE2F0AFE /* Support Files */,
+				3DF5C2ABFBE30CA66E8118A7D53882D8 /* Algorithm.swift */,
+				6115345D980F0556C6332245CA345F5A /* AnyDifferentiable.swift */,
+				6B3BA0BCB0DE172930CBEF888CFF73EB /* ArraySection.swift */,
+				E5150628D0C3DDF4CE1EDDBE64810EF1 /* Changeset.swift */,
+				CFF2C29F96615B40A37A0CD796794FA8 /* ContentEquatable.swift */,
+				9014FC05E8F6E9C0478938C470E53ED0 /* ContentIdentifiable.swift */,
+				780C99873DB13B4722413879850158E2 /* Differentiable.swift */,
+				E969AB5B1BAA38DC9DDCC42393F1B3B7 /* DifferentiableSection.swift */,
+				72359285018337286FC39596CA366C49 /* ElementPath.swift */,
+				F541104E82B4BE54EE77FE77A2BA07EB /* StagedChangeset.swift */,
 			);
-			name = Impose;
-			path = Impose;
+			name = Core;
+			sourceTree = "<group>";
+		};
+		0D6FD5AA3AEB86F58BF6E361081C9E89 /* Quick */ = {
+			isa = PBXGroup;
+			children = (
+				862B7E338C8F5ED7AE930AAA01E7A87E /* Behavior.swift */,
+				69874B3F269F3E5EF41C576485A481B7 /* Callsite.swift */,
+				BF61774000E7A82647EA088F8534FE8C /* Closures.swift */,
+				C21BAEB3413ACCE398AB1857021DD512 /* DSL.swift */,
+				FD450F904AA2B25734A4684283C2031B /* ErrorUtility.swift */,
+				8F38BE71F309685F2FBB4E97C07762CA /* Example.swift */,
+				96F886AB1120AD45B880AD54B91DD455 /* ExampleGroup.swift */,
+				A8115C8FCE56D8B08764BAFEBF357213 /* ExampleHooks.swift */,
+				4F4AD0DD2AA7544F961631D73670F17D /* ExampleMetadata.swift */,
+				359E7CCA46718B35B888F399B903A4B9 /* Filter.swift */,
+				138CE0A74585D52955307BF289A4535F /* HooksPhase.swift */,
+				D2055F787F1ED2C488492A76AC2ED170 /* NSBundle+CurrentTestBundle.swift */,
+				B1AEB7CF644CB3D46AAA0A444C99495D /* QCKConfiguration.swift */,
+				FB82ECD0B5EFF8BFB731AAB2886E6BD6 /* QCKDSL.h */,
+				D0492BCE3BF1DBBEE3F866286D283E0D /* QCKDSL.m */,
+				88F2B3D13A94367B19D0B7834299462C /* Quick.h */,
+				AC131BCEA2B6B7F4927EB980C0283274 /* QuickConfiguration.h */,
+				72E0049ED94E764B84FAEF0115C91084 /* QuickConfiguration.m */,
+				140062391D682A565AD648026E4E457D /* QuickConfiguration.swift */,
+				D43BFE8393EFD717CB3E59EA90EAD967 /* QuickObjCRuntime.h */,
+				A422D5BB4C544536C7365E1DB3870D85 /* QuickSelectedTestSuiteBuilder.swift */,
+				33D39BB5086838B625545698C799FA66 /* QuickSpec.h */,
+				3B53FDCB52425FA777C6A028903B7A93 /* QuickSpec.m */,
+				F309142BD044D3A3EB694AE997AD8D54 /* QuickSpecBase.h */,
+				FE992045BC959155A2E98F8F50E08AE4 /* QuickSpecBase.m */,
+				C8362060E458F5BFC4BDF7249605B707 /* QuickTestObservation.swift */,
+				3B534E42655245FAB9C69A4487F1065C /* QuickTestSuite.swift */,
+				19564BE517BD21456F219972F53F8CE7 /* String+C99ExtendedIdentifier.swift */,
+				2C02A346FD15D3F5476714B23F5171D1 /* SuiteHooks.swift */,
+				073843B45712907BA4EB44E78ECE5D9B /* URL+FileName.swift */,
+				8BC1EDB602505BD76D34AE87C42765BE /* World.swift */,
+				ADE8FF5F1C49D5792C32803D3505E4F2 /* World+DSL.swift */,
+				A20FA603F61E844FADA7E97683CA5E17 /* XCTestSuite+QuickTestSuiteBuilder.m */,
+				542F44B2E287490F0879610D4D017D44 /* Support Files */,
+			);
+			path = Quick;
+			sourceTree = "<group>";
+		};
+		11BD50A996C4899240193745218FD3EE /* Clavier */ = {
+			isa = PBXGroup;
+			children = (
+				CAB672C174FDDB9C34E15D27F97579B1 /* ClavierLayoutGuide.swift */,
+				15B620BE5D0A41075A55ACD16A85699D /* Extensions.swift */,
+				1F1B97A754B428D562946AFADB43864D /* SafeAreaKeyboardLayoutGuide.swift */,
+				C223674545AE969F5E123D27811307EE /* Support Files */,
+			);
+			path = Clavier;
 			sourceTree = "<group>";
 		};
 		16E8F9EF096B3C13E8EA5328523B945C /* Targets Support Files */ = {
@@ -1143,92 +1197,91 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		17E1533CB3BB71069ACBBDEAA8ED8B84 /* Chary */ = {
+		172A72606E4E558AC489F1DFD22A7775 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				14DBC7CBDA5471F0BE50D3622F7D5EAF /* Atomic.swift */,
-				F5871F2D8BD5FA7A8F36D8D1E00C3919 /* DispatchQueue+Extensions.swift */,
-				A4D37D43AE78CAA954F1EEEFA31EA59A /* Support Files */,
-			);
-			name = Chary;
-			path = Chary;
-			sourceTree = "<group>";
-		};
-		1881CB63ECEB969F6DCF901EE2C51C38 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				F5ADABE308A64D70FC62D843CBEFD7FB /* Quick.modulemap */,
-				6053046482A15766D6A1C2DEF70B8A5F /* Quick-dummy.m */,
-				E8E9ABE261BA9648CC5D6A16CC92AA80 /* Quick-Info.plist */,
-				8FBC34FBDA58317A391F56CAB5BB5003 /* Quick-prefix.pch */,
-				FDF15EEAAB47AC41015F3959F43DAF18 /* Quick-umbrella.h */,
-				53A8803D10A2BDE2A00EC9C3A280DE2F /* Quick.debug.xcconfig */,
-				1BFE6958271DB0C607615D388C8B94B9 /* Quick.release.xcconfig */,
+				0415A5C9BF9A2562678007B604AA26BD /* Nimble.modulemap */,
+				AEF87C07788E7106769ED61D4BACBE86 /* Nimble-dummy.m */,
+				E42A9BE4B19FCB4CE576B7396BFC5C08 /* Nimble-Info.plist */,
+				A25BF5E500A9E2235FAF79BFEBFAAF2F /* Nimble-prefix.pch */,
+				1AE05D6CB733F1E9FF92736AC05AAC74 /* Nimble-umbrella.h */,
+				736AD2086D82A47487CAE44FF912DFB8 /* Nimble.debug.xcconfig */,
+				C2A12BEA6A42BE446EED9D1986872C6E /* Nimble.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/Quick";
+			path = "../Target Support Files/Nimble";
 			sourceTree = "<group>";
 		};
-		21164578E956F6C74100D58F0F740125 /* Core */ = {
+		1A9528F77C8E07842879A228CCDA7044 /* SwiftSupport */ = {
 			isa = PBXGroup;
 			children = (
-				E9E8062690C092BDCDE2886F0200656A /* FBSnapshotTestCase.h */,
-				C22B0DD847385FFBA9A7D93E318F35A7 /* FBSnapshotTestCase.m */,
-				637217F02BB06F450F12E4594C1BB921 /* FBSnapshotTestCasePlatform.h */,
-				CDB0343BE61468CA36A4E2E5B95B018C /* FBSnapshotTestCasePlatform.m */,
-				A490B2F62EC1971152B2AF116E684140 /* FBSnapshotTestController.h */,
-				A1DA37CEA2CFF8889284A1DA7C81F838 /* FBSnapshotTestController.m */,
-				C61E47D6447772A0396A8C2FAEBE597C /* UIImage+Compare.h */,
-				80F3FB96FA13DB499426A23FA7816700 /* UIImage+Compare.m */,
-				DF8474C5E95F98A5EF474612071F7087 /* UIImage+Diff.h */,
-				5C8B34DB23A19B22E3DAE3E50BEBBCDD /* UIImage+Diff.m */,
-				B06E2BE5402C4DED46CE9233092922C1 /* UIImage+Snapshot.h */,
-				50A9942D2C54ACE9FD03CC16950143E5 /* UIImage+Snapshot.m */,
+				8A93A1036ED2EC26102002AFAED3A135 /* SwiftSupport.swift */,
+			);
+			name = SwiftSupport;
+			sourceTree = "<group>";
+		};
+		1E1A48D6ABB91CB19CCE80C8F0292C36 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				863F7DD09E142C5FAC8FBAE1EE9EB761 /* DiffableDataSources.modulemap */,
+				20576AE59007C9DF9C9F9C11A85EAE24 /* DiffableDataSources-dummy.m */,
+				F7D1A0301AB1FF9F81B9B0A8E6A35089 /* DiffableDataSources-Info.plist */,
+				B5169441A14DCD184E4FD17B52138545 /* DiffableDataSources-prefix.pch */,
+				4F82CC7A3FFC71B7A0F1166DAFA6EA23 /* DiffableDataSources-umbrella.h */,
+				22688060E68A2B16A4411777150EDB18 /* DiffableDataSources.debug.xcconfig */,
+				E969ED978719FCE351F985AF4944D1B5 /* DiffableDataSources.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/DiffableDataSources";
+			sourceTree = "<group>";
+		};
+		22F3A1B01D30421DA66024AB8C42A13B /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				8215801333035857FBFC89E285C49053 /* CurrentTestCaseTracker.swift */,
+				8B57699296657D79CAA785094F2473FE /* DynamicSizeSnapshot.swift */,
+				5035C15F1998776D6A7BF4CCE12BC7B9 /* HaveValidDynamicTypeSnapshot.swift */,
+				3399C4F6C2473DF25DE82F2EC6CFAF41 /* HaveValidSnapshot.swift */,
+				4E54AF4ABCCADB83C4BA93AEDB2A2D32 /* NBSMockedApplication.h */,
+				27837971E417F85EB03E879791E6F54B /* NBSMockedApplication.m */,
+				FA194F10DB279BD3B8900C5EB29D3C57 /* Nimble_Snapshots.h */,
+				E07F54E35250ED85E929AC5EFAE40F44 /* PrettyDynamicTypeSyntax.swift */,
+				3D3AC22A74BF5FD2CACCE09BE89A3EE3 /* PrettySyntax.swift */,
+				DB4AFA40F5765F599F01498E9CB7A35C /* XCTestObservationCenter+CurrentTestCaseTracker.h */,
+				D5AE692E2EB0B0AEFEAAED8B489EA021 /* XCTestObservationCenter+CurrentTestCaseTracker.m */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		2285240D773A7B892B3325C594377CF1 /* DiffableDataSources */ = {
+		295845DC334E6A04CDE9716E1EEAC4C8 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				5FD93D2494BDC47F3D6375B3627185B4 /* CollectionViewDiffableDataSource.swift */,
-				461A6EA77ED58EF823CFB13ED29303D9 /* DiffableDataSourceCore.swift */,
-				338DCF99BBA3285919D0EF8C6E24E157 /* DiffableDataSourceSnapshot.swift */,
-				7ABDE83C8DF944F8AFB50BEFED09C5C9 /* HashableExtension.swift */,
-				FA02F9EAD65B3866B7E6D0F4B770F39F /* MainThreadSerialDispatcher.swift */,
-				9F678919E0FAD0B365E60F42B0CD2307 /* SnapshotStructure.swift */,
-				598E95839933806B8921D5C8DE28F6C0 /* TableViewDiffableDataSource.swift */,
-				C14896559753F34301A2D6B7932C2968 /* UniversalError.swift */,
-				EA8DC365052AC3CCB992F2C4650BFADC /* Support Files */,
-			);
-			name = DiffableDataSources;
-			path = DiffableDataSources;
-			sourceTree = "<group>";
-		};
-		22E3695B3BA9CA2EF1DA83DF21FA9C52 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				072C9AE6A1259056F7A695A339EF2C4F /* FBSnapshotTestCase.modulemap */,
-				116919CED1B53F03220C837A941F0125 /* FBSnapshotTestCase-dummy.m */,
-				B72EBF0D4023050021F500E9A2D38F8B /* FBSnapshotTestCase-Info.plist */,
-				726D79DC7EAC9314100EA8E05D1DCD27 /* FBSnapshotTestCase-prefix.pch */,
-				65E8B2D287DC125B5C365739F1B490BA /* FBSnapshotTestCase-umbrella.h */,
-				7CA99F85DB68C7BBF5356E0AD2292AFF /* FBSnapshotTestCase.debug.xcconfig */,
-				78C08F3164FC77E466D6A3CD454C74E5 /* FBSnapshotTestCase.release.xcconfig */,
+				E17A5AEC3E5916CE23EE63AEC5B80820 /* Impose.modulemap */,
+				ED69060AD03A2693E157EAE1FE9C9FD9 /* Impose-dummy.m */,
+				86BF674E0F63FCE2C2FF5EEB81C1CC33 /* Impose-Info.plist */,
+				ECEF1543CB3BCCDC444748BD51670C4B /* Impose-prefix.pch */,
+				F5FCA74EC5519B8C0B122E0EFA9C4AA8 /* Impose-umbrella.h */,
+				55F88247D714C9BCECBBF8652FE7C349 /* Impose.debug.xcconfig */,
+				4F86955306047FF945EE406376D988C7 /* Impose.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/FBSnapshotTestCase";
+			path = "../Target Support Files/Impose";
 			sourceTree = "<group>";
 		};
-		2845860D4982456777055DEA6B6369EF /* FBSnapshotTestCase */ = {
+		2E6348DB5402F35C5257A1C066D79AC8 /* DiffableDataSources */ = {
 			isa = PBXGroup;
 			children = (
-				8F749304F21D4CA7918C3CD981E2A376 /* Core */,
-				22E3695B3BA9CA2EF1DA83DF21FA9C52 /* Support Files */,
-				9810F0B46396C0E3A2AFC7F42B7EA359 /* SwiftSupport */,
+				1A148A1ED371EA196D66E562169C764D /* CollectionViewDiffableDataSource.swift */,
+				E4BEFEEF45D922E53EC7E9A20A2A7432 /* DiffableDataSourceCore.swift */,
+				D4648DBA99775EDEE965856D13AE52A8 /* DiffableDataSourceSnapshot.swift */,
+				771BA57969418A28D008EA70AC1428AE /* HashableExtension.swift */,
+				839651B9A3ED124E05D79285E1342857 /* MainThreadSerialDispatcher.swift */,
+				B46599AE5A0C611FC09CF8438660458D /* SnapshotStructure.swift */,
+				D0427D7265C12F833F973F27314FAD4A /* TableViewDiffableDataSource.swift */,
+				077606C1F799C94688BF86BDBDDE1FD2 /* UniversalError.swift */,
+				1E1A48D6ABB91CB19CCE80C8F0292C36 /* Support Files */,
 			);
-			name = FBSnapshotTestCase;
-			path = FBSnapshotTestCase;
+			path = DiffableDataSources;
 			sourceTree = "<group>";
 		};
 		307B59FAC059E09730A5423D270D3161 /* Pods-Artisan_Tests */ = {
@@ -1271,97 +1324,49 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		360CF694B296E31D0A930197348100DD /* Builder */ = {
+		37D4297A8B02D3641271A7DB3A429FC1 /* Pharos */ = {
 			isa = PBXGroup;
 			children = (
-				DE04C7FB4214A8F79CAA22CE977D225B /* Buildable.swift */,
-				039D2F5BF85464810822619F63ACF2D7 /* Builder.swift */,
-				C7984627147E649F201C684CB5CDCFFA /* BuilderConfig.swift */,
-				8C6D2F146291D9143E041E631C67E3DB /* PropertyAssigner.swift */,
-				87680CDFD97FDF347B80712D64CC06E3 /* Support Files */,
+				E40276C1791F702619BC497A310435C5 /* BaseProtocols.swift */,
+				496C445CE5F70C0D6255CE0989598E46 /* BindableCollection+TextInput.swift */,
+				57AD3D9B819ECE13AACD57CEF8CA9C4B /* BindableCollection+UIButton.swift */,
+				9FBE19E94D69FE1BBD172BB9A5515781 /* BindableCollection+UICollectionView.swift */,
+				9FF77DF15101029DD52CA5FB1BBB233F /* BindableCollection+UIControl.swift */,
+				167FC2DFEAF1BE295D182FFF693008C5 /* BindableCollection+UIImageView.swift */,
+				85EC89C31D92EBD7585C66594467491C /* BindableCollection+UILabel.swift */,
+				11DDDF5B0A0F397D66D144F393A337C2 /* BindableCollection+UIScrollView.swift */,
+				C6174C9B77403AE99CA3044A42A8EC81 /* BindableCollection+UISlider.swift */,
+				4AF71DB9FC15504A681CDE32E585F700 /* BindableCollection+UIStackView.swift */,
+				E6C1AA4976F684F9222D4FCC6D92820A /* BindableCollection+UIStepper.swift */,
+				63773A0754DDFB345DDB4958B2171E8A /* BindableCollection+UISwitch.swift */,
+				2DC0EC031A806026B8DBD5036426CCF4 /* BindableCollection+UITableView.swift */,
+				E17DCC147768DED6F51EC2B5D62D195E /* BindableCollection+UIView.swift */,
+				6DE5CB2B34860BC739B5B3E30676774A /* BindableCollectionCellView.swift */,
+				4BFBFB8102BC67FCF7EEE9B108A70FB6 /* BindableKVOObservable.swift */,
+				382A55601270B70E371C84D180E3DD79 /* BindableObservable.swift */,
+				8A1EDAAA84402FD96B5DFCD097F99F7F /* Changes.swift */,
+				D31086BA04FDF4933C31013C7FC9EC2B /* Dictionary+Extensions.swift */,
+				81500AF4AFA894D9404262ACBD9274FB /* FilteredObservable.swift */,
+				195F5B9E6987992261A5644E7AB5A7E5 /* MappedObservable.swift */,
+				DFBBCE1557736117F9087022832E70CE /* MergedObservable.swift */,
+				1D95A3739747F6D8E5F08B964B1A5CE1 /* MulticastObservable.swift */,
+				52C357CC4F83E907EBC7C57371695010 /* ObjectRetainer.swift */,
+				39EC6212B74498ECCFB32485DC8F995E /* Observable.swift */,
+				BC94E2A5AA0C6DF4F61B60F52D99318C /* ObservableBlock.swift */,
+				59BB44E8E1EC29EBAC3D595062201982 /* Observed.swift */,
+				87BFB9FF4B3FFD029A1F6401F9840F3A /* PharosContext.swift */,
+				E1CF1B093537F4DBAFF5A7D31F69C209 /* PopulatedRelays.swift */,
+				5AA902042566B507F124F51C452215E5 /* Publisher.swift */,
+				CA9A656426259B3441D2BA08A88EF2AE /* RelayInvoker.swift */,
+				CC6229B0CD8E96ED8F76C41BFA7BAE3F /* Retainer.swift */,
+				F0C90DCAD2ECBAAD0BD5AE144863BC0C /* RootObservable.swift */,
+				83EAB420B92C4CADBDD8BFBACDC83EF5 /* Subject.swift */,
+				43FE248E6C827424F70FCA7E36086ECA /* UIControl+Extensions.swift */,
+				95F09C7987A82245AC9D22FCC83983E9 /* UIControlAction.swift */,
+				F1A7BCB53C87F305F3ECBAF24B5C860A /* UIControlSubject.swift */,
+				EA1CCB7F6F486A5E9E3119E072FB2505 /* Support Files */,
 			);
-			name = Builder;
-			path = Builder;
-			sourceTree = "<group>";
-		};
-		3BF2142D05B26F70741DF3DBCE73C427 /* Nimble */ = {
-			isa = PBXGroup;
-			children = (
-				481AB0A8186CFE0CAB0B664C83E7ABE1 /* AdapterProtocols.swift */,
-				795C671C529F20CE73E4721AAB8F6809 /* AllPass.swift */,
-				208AFDC82EE25E28BDCC9EDB19CFF78C /* AssertionDispatcher.swift */,
-				DBFABBF7638B2D98E38AF38BA19C7D4E /* AssertionRecorder.swift */,
-				F86F8711879153EC95FB09F62D41F0DF /* Async.swift */,
-				6A5C7D0634FEC0A3A4B7737E0C93F71E /* Await.swift */,
-				A251B732798AFC40B71AC9CFFF9C2EEF /* BeAKindOf.swift */,
-				75E93D1ECF93B321BD6EBA755387AB13 /* BeAnInstanceOf.swift */,
-				C321D660A3A039C92AFF5EC6568C84A4 /* BeCloseTo.swift */,
-				F7279BFE3593C038F922B8075BC930FD /* BeEmpty.swift */,
-				C94973BE36813745D40773DEF1E94862 /* BeginWith.swift */,
-				C18E47C3136CAA8450CF75B91D1BF625 /* BeginWithPrefix.swift */,
-				B882EE91D19B7E057370DF90349F0D39 /* BeGreaterThan.swift */,
-				56B4ACC27BC777A02CF3E46AA2ECD3AE /* BeGreaterThanOrEqualTo.swift */,
-				B446FD412422B0711C9D35FE6CDE3F8B /* BeIdenticalTo.swift */,
-				361ED4D2FF4042A8D5CE4E45FC756370 /* BeLessThan.swift */,
-				910BF5CAB2F64C252ED3133D0C7E3AA0 /* BeLessThanOrEqual.swift */,
-				3EC71B5B5F7E28282392D4AB25855397 /* BeLogical.swift */,
-				25AF9646DD8EF00609F884B5D0709DB8 /* BeNil.swift */,
-				25DF8EC9C18CFF1F4E4ED4E9EC4B6624 /* BeResult.swift */,
-				24731B08BF7778703311E0388B647FC6 /* BeVoid.swift */,
-				AEC0B9A19C9416482F7687FE5B6F50D7 /* BeWithin.swift */,
-				EAEEA9C8039CC76007D04EF53BCFC43E /* Contain.swift */,
-				BB96A42E6A29814E9993D065AE489B0C /* ContainElementSatisfying.swift */,
-				FFC3AD31675EC3ED4DA43C1F45048076 /* CwlBadInstructionException.swift */,
-				CA8378862E5657D3E81B13FA3E9FB998 /* CwlCatchBadInstruction.swift */,
-				684B3930A71D239368783ED680809ED6 /* CwlCatchException.h */,
-				707153269BF13501493C162D115689EF /* CwlCatchException.m */,
-				4C2105906B93F65A2F49738C2F73D344 /* CwlCatchException.swift */,
-				247FC627095A5289654BCD5EDB3344A8 /* CwlDarwinDefinitions.swift */,
-				9DE62266F808CBFD0D6623A33DFD2A27 /* CwlMachBadInstructionHandler.h */,
-				13A26E597F85833A5DBEB72D41506ABF /* CwlMachBadInstructionHandler.m */,
-				379D9D9BF59BB007E1C8FC9D850B3C0B /* DispatchTimeInterval.swift */,
-				0A14A4B7BAFF38B8A86BB376CB4A8D80 /* DSL.h */,
-				A0A5AB4EAB0E7A99B017DA9E4D740E04 /* DSL.m */,
-				72A76C7B0359AB60C345E0243CE8AC43 /* DSL.swift */,
-				2CB8499B9BA02D1623600AEAC915BDAF /* DSL+Wait.swift */,
-				9B6F758F7E96FEB297B9B1029DDCF00E /* ElementsEqual.swift */,
-				35AE296C3182345CEC928D48A23B1840 /* EndWith.swift */,
-				93329935943431AA1091E935BAD68EF6 /* Equal.swift */,
-				CAD901917E019C8ABD4A7789A1CF13F4 /* Equal+Tuple.swift */,
-				19543F9F650566C4F4987E4E42013C21 /* Errors.swift */,
-				4EF3A019400B5734A24B45703228637B /* Expectation.swift */,
-				79B940F31E7DCE39678C3E125F3A69A0 /* ExpectationMessage.swift */,
-				38AA40EE0532F8F52AD329802954B1F9 /* Expression.swift */,
-				5F0403B771FD9C4E62D1CB303801A276 /* FailureMessage.swift */,
-				941977223A9A0B4DF269C119C4BFDF1C /* HaveCount.swift */,
-				E5C23D4845530804A03AF0BFC7F3470B /* mach_excServer.c */,
-				560F0259FE9CF1CD6C1CB28DB49CECFF /* mach_excServer.h */,
-				8AB6C7B5066447F0A7DA7B5429D95B08 /* Match.swift */,
-				B89A78F0D4B73383F387FE43B9A8081E /* MatcherProtocols.swift */,
-				4FDBDF140EC034E0BAD97E6742F33BC9 /* MatchError.swift */,
-				F9408342CC9ECC49567A9B4ECACB23BA /* Nimble.h */,
-				12AD0ADA33523EEB4893EDD223B91C33 /* NimbleEnvironment.swift */,
-				5EFD3CCCCE07CE0D1393442A2D71CC3F /* NimbleXCTestHandler.swift */,
-				D4A68C7DF5D05CE684BAA1B3B6C7B982 /* NMBExceptionCapture.h */,
-				E1C2655283A979119409EFA45B5BA703 /* NMBExceptionCapture.m */,
-				38C69B45238F09C84A73D8FA656194E1 /* NMBExpectation.swift */,
-				929DC0A856CC06157FC87654231ADBCE /* NMBStringify.h */,
-				1F0EE6D378EE9C97DCFE4E72C8B21079 /* NMBStringify.m */,
-				205E5C7A9F4E5987055BB4C5220CC1F0 /* PostNotification.swift */,
-				A5C4EA59F720E9CD8FA617D9D0353564 /* Predicate.swift */,
-				22B57DA84B91C4D2D992EF3C79B08A93 /* RaisesException.swift */,
-				080EC1F735EA930A87CFC5B6B223688F /* SatisfyAllOf.swift */,
-				EB938A476F8019D4D145BC31AE3E614C /* SatisfyAnyOf.swift */,
-				0F7D4F7D0291544CE5655A2EBA52B655 /* SourceLocation.swift */,
-				96A598FAB911A90E8FE58B78A829ECDE /* Stringers.swift */,
-				113B2ED3110211EB9C756CA9061B3ED6 /* ThrowAssertion.swift */,
-				A7F237A74B8BB1E27B08E12C2BDA9B2E /* ThrowError.swift */,
-				491828D6127E09592D5F8141593540C2 /* ToSucceed.swift */,
-				814D6D5CAF570678DCA959940879DC39 /* XCTestObservationCenter+Register.m */,
-				0E041F3E3BA49110691E6BBE783EF036 /* Support Files */,
-			);
-			name = Nimble;
-			path = Nimble;
+			path = Pharos;
 			sourceTree = "<group>";
 		};
 		3F43D981FA96BAEA3A5358DFF08AB998 /* Utils */ = {
@@ -1380,9 +1385,41 @@
 			children = (
 				204A70EA8EF89FDDB7814F9642AC1AD0 /* ViewBindable.swift */,
 				4A321BFA6052FE6B5BD5AB4570F4063E /* ViewModel.swift */,
+				BBA2E6EA286FD3D00055AE11 /* ViewBindable+Retaining.swift */,
+				BBF057DB2871C66F00D34444 /* Observable+Binding.swift */,
 			);
 			name = Binding;
 			path = Artisan/Classes/Binding;
+			sourceTree = "<group>";
+		};
+		4D4AABB32BEA85B21E14BFE711DCA8F8 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				C83519F8C3F54501C46543D40A68A3CF /* iOSSnapshotTestCase.modulemap */,
+				9333ABD679D60CE2C93C9573E586E0F2 /* iOSSnapshotTestCase-dummy.m */,
+				BF0C0D6660D2C3E33BF27FCB8A778D3D /* iOSSnapshotTestCase-Info.plist */,
+				FB58ECE7C4CFB36B862F312B86184DB8 /* iOSSnapshotTestCase-prefix.pch */,
+				F462465104147BB4A144BC12AB4056D5 /* iOSSnapshotTestCase-umbrella.h */,
+				E8FC9766B25F6F3ED1E0A7512AF6E8D1 /* iOSSnapshotTestCase.debug.xcconfig */,
+				0C231FEE47A69341802AA68B0EAD94DC /* iOSSnapshotTestCase.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/iOSSnapshotTestCase";
+			sourceTree = "<group>";
+		};
+		542F44B2E287490F0879610D4D017D44 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				60429C7B7502FD8F4E0D576B78BE80C0 /* Quick.modulemap */,
+				2B11DB1DC4C24B95BA829B2B7703289B /* Quick-dummy.m */,
+				20EE729E07C1235598D8307EF0E3FF2E /* Quick-Info.plist */,
+				4AC67F065CF5BC781DC993A55BD4772F /* Quick-prefix.pch */,
+				738DB8348A74CF2E7BBADC057CEE838B /* Quick-umbrella.h */,
+				9E2354BD3A5A609612C2576D995BA8CF /* Quick.debug.xcconfig */,
+				9170A982344457F661E138494928C083 /* Quick.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Quick";
 			sourceTree = "<group>";
 		};
 		5B8C1342BA1B018FE503780674214142 /* Pod */ = {
@@ -1395,32 +1432,51 @@
 			name = Pod;
 			sourceTree = "<group>";
 		};
+		63267E8AB4142287406672B65C23DCE1 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B3C7A5A04506DCE72EF2E6327823E765 /* Chary.modulemap */,
+				092B025FA20152BF9A091DDA80929378 /* Chary-dummy.m */,
+				283C3DFC4A7E28D069008748815CF81D /* Chary-Info.plist */,
+				73C2CED58F9B57BED8B86CE735BB3106 /* Chary-prefix.pch */,
+				B4AD9CD203F70ACB3E195F22431ADE3E /* Chary-umbrella.h */,
+				775ED9FA2E33C3C4F22F7ABA1AEC19CC /* Chary.debug.xcconfig */,
+				F782AB11AD5E9B56FD9A59B972E00D65 /* Chary.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Chary";
+			sourceTree = "<group>";
+		};
+		6675D4C5D9180CA3A8B2E1432A67CC74 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				9CA1D7C7FF0EF8B627F589C33E9090FA /* Draftsman.modulemap */,
+				966C737E4D26410BBC1A6CAE82B3A4D9 /* Draftsman-dummy.m */,
+				CE0AA3CA9258952746C5046535F3B4C8 /* Draftsman-Info.plist */,
+				78DF786636EC17F6841EC06F62533D8C /* Draftsman-prefix.pch */,
+				57751974DD2DA624E2A6EF34F6CC73D1 /* Draftsman-umbrella.h */,
+				AC521E5EC20BD9EBDCEE402A29B7E1D2 /* Draftsman.debug.xcconfig */,
+				C7B99FB5C27E6ABFBDE288D89C281A6D /* Draftsman.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Draftsman";
+			sourceTree = "<group>";
+		};
 		686295C74FD433E10931031ACB0E04AA /* Stack */ = {
 			isa = PBXGroup;
 			children = (
 				2775B18D8D33776758AEDE3238E651D0 /* ScrollableStackView.swift */,
 				6A7C46E2D61F96106CF4CDEDC0C6D4D8 /* StackBuilder.swift */,
 			);
-			name = Stack;
 			path = Stack;
 			sourceTree = "<group>";
 		};
-		751853C4FFF83D31E6D0792615C3F6E0 /* Core */ = {
+		6E1FD2DD659F84E021BD1BEC953333D8 /* UIKitExtension */ = {
 			isa = PBXGroup;
 			children = (
-				EFAD07ED4D9C4D337A37AD812B7192F7 /* CurrentTestCaseTracker.swift */,
-				3A5E0A775E484E6F762BDE377BE09C2D /* DynamicSizeSnapshot.swift */,
-				BDD10CCC395D25CD767B25B745C69822 /* HaveValidDynamicTypeSnapshot.swift */,
-				25ED72AD9B3A49B0A2F044BD6A42AAC1 /* HaveValidSnapshot.swift */,
-				AFF49DF38AA0802F8827B1691C87D4AF /* NBSMockedApplication.h */,
-				C5C7F9616050C2986E479A4B1D24AD07 /* NBSMockedApplication.m */,
-				47E2C2FEFF5FB3BDF0F73F62177FF04A /* Nimble_Snapshots.h */,
-				8894E94E09A813B56AAF7F9A0408DB61 /* PrettyDynamicTypeSyntax.swift */,
-				0DD742B226C7AECA5E6FC740C01AE551 /* PrettySyntax.swift */,
-				940091854BAF3314743B88BD11043B89 /* XCTestObservationCenter+CurrentTestCaseTracker.h */,
-				31B8A16F787055DA4E2AA900A60FE4E9 /* XCTestObservationCenter+CurrentTestCaseTracker.m */,
+				04548115C406B5083D2C4EF6AED037BF /* UIKitExtension.swift */,
 			);
-			name = Core;
+			name = UIKitExtension;
 			sourceTree = "<group>";
 		};
 		758367579B060FDD203030C286F9E871 /* Artisan */ = {
@@ -1437,267 +1493,210 @@
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		87680CDFD97FDF347B80712D64CC06E3 /* Support Files */ = {
+		789BE56AB8615F7DF35919D81FC0B560 /* Impose */ = {
 			isa = PBXGroup;
 			children = (
-				0D7382163DE54559E7DA8CA07A8615A6 /* Builder.modulemap */,
-				5A6888AAD71BBDE61BFD3AAF42213C1F /* Builder-dummy.m */,
-				E9738AE1D34A7973355B68F98B6E3702 /* Builder-Info.plist */,
-				2EB0500D2A0AA5D3649F614BCFE23DBF /* Builder-prefix.pch */,
-				8E25CA2115280857E254C83343CEF68F /* Builder-umbrella.h */,
-				1F4C05F15B014CDEFA1D8CE40D529B2D /* Builder.debug.xcconfig */,
-				FBD6ADF6F2F09EE90046BA1AB6907512 /* Builder.release.xcconfig */,
+				95B6C590BDD4780009EAA6D9DA337FDE /* Dictionary+Extensions.swift */,
+				B552FC5FE0C95E8C842ECA0E352547E2 /* ImposeError.swift */,
+				32BA8A8AAC1064893E2A83902BBDDD54 /* ImposerCompat.swift */,
+				AA06165C4EC18EFE4D5624DD11EAE435 /* InjectContext.swift */,
+				080AA22494874DC9D005B3FEAE1C6894 /* Injector.swift */,
+				E16DA6F75AD70A35F08DEE2351413D20 /* InstanceResolver.swift */,
+				EECE95321F63A2E957E29B7045E2FADC /* Mirror+Extensions.swift */,
+				57947969E6D853BA69C70D02F764123B /* ModuleProvider.swift */,
+				61E793A0179FC848D812A8C566E36B99 /* PropertyWrapper.swift */,
+				EC08D7E26C1209B407C76A391724D1D9 /* ResolverFunction.swift */,
+				0E0295041581E98C152C6EAA14C48F97 /* Scopable.swift */,
+				EB124C4D47C4B109D574BA2CCBF3657F /* TypeHashable.swift */,
+				295845DC334E6A04CDE9716E1EEAC4C8 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/Builder";
+			path = Impose;
 			sourceTree = "<group>";
 		};
-		8B7799AC50C7A6F401D098E78235EB77 /* Support Files */ = {
+		7F97FC61CE6B3F693AC214DF1B2E709A /* Builder */ = {
 			isa = PBXGroup;
 			children = (
-				6B1C4F95C5FF88166E7B00C4EBA62642 /* Pharos.modulemap */,
-				2EEF34D60DBF7221FF5C141271DD5E23 /* Pharos-dummy.m */,
-				43C5F566B893CC8892D0CA988BBC3DE4 /* Pharos-Info.plist */,
-				CDC23B594EF5A767ED37B2994819B304 /* Pharos-prefix.pch */,
-				04CD123B00C52F5985BDFFF81F339DD1 /* Pharos-umbrella.h */,
-				EAE3ECC13C5B9B6D608F1D3C4D12FA97 /* Pharos.debug.xcconfig */,
-				419B1E0D34FBB374618C2B9B4F9A35CC /* Pharos.release.xcconfig */,
+				ABC4702B8DD851EAA0D60C2C6A2A8EC6 /* Buildable.swift */,
+				1CBD5BBF10AE1CB5C4FF0C39AE105A1E /* Builder.swift */,
+				E4CADB8F3B95641242DC1BBD53A279FD /* BuilderConfig.swift */,
+				5D29A2980DF760562AF1E27A12D163A5 /* PropertyAssigner.swift */,
+				C66BB34B0D26C26AEDA1BDDCF46A569F /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/Pharos";
+			path = Builder;
 			sourceTree = "<group>";
 		};
-		8F749304F21D4CA7918C3CD981E2A376 /* Core */ = {
+		8A9183C6AE18B232D740888579CB9006 /* Chary */ = {
 			isa = PBXGroup;
 			children = (
-				BF6D1C3C83ECEB5F19F8EBC10113DE1E /* FBSnapshotTestCase.h */,
-				37E1FBC050FF9EC462546E7C5E4DBFA5 /* FBSnapshotTestCase.m */,
-				DABDA0FD6F2E305012326F8CEE10D76A /* FBSnapshotTestCasePlatform.h */,
-				2116703722EDA0171F5C208173B70691 /* FBSnapshotTestCasePlatform.m */,
-				CBA89870AA9EAE8927914B63A7CA1C79 /* FBSnapshotTestController.h */,
-				1349149C334A58270EE0D3DE80512ADF /* FBSnapshotTestController.m */,
-				3B4C315FAA47AD6C9BC4481F16C11390 /* UIApplication+StrictKeyWindow.h */,
-				014DF8974B85AB955C8A9EE26F71ACF8 /* UIApplication+StrictKeyWindow.m */,
-				151419F1D17BB2AFBE291BE6603281DD /* UIImage+Compare.h */,
-				BA17DF457CFBD231322647992FBA2C23 /* UIImage+Compare.m */,
-				596B36A1643F56BF912E08FF0BD7616F /* UIImage+Diff.h */,
-				FF239F2678DC67F57B9EFE59DF6CA32B /* UIImage+Diff.m */,
-				3A6B75F02C88D51A4CA04DFD44923FB5 /* UIImage+Snapshot.h */,
-				DD11EE05746340EA381D5D32DB6D96CB /* UIImage+Snapshot.m */,
+				AC20B956EC210DAB2CF6F8199575A6E6 /* Atomic.swift */,
+				4B60884EEFBE9DC817336288FBAF5A7E /* DispatchQueue+Extensions.swift */,
+				63267E8AB4142287406672B65C23DCE1 /* Support Files */,
+			);
+			path = Chary;
+			sourceTree = "<group>";
+		};
+		8BB973950A2BC2F6D15724C2F31EA95D /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				B0E51E0B834287C702C906BAD9CBE9E1 /* FBSnapshotTestCase.h */,
+				AE5F81D6211CA97CC73304A3C24B3CFD /* FBSnapshotTestCase.m */,
+				C2798D37C3B7A9B9B72904ECECBADCAE /* FBSnapshotTestCasePlatform.h */,
+				4262D15483B148E863D8AD635B8248B3 /* FBSnapshotTestCasePlatform.m */,
+				0F69A269AC77D3F59D202D2142035811 /* FBSnapshotTestController.h */,
+				D4557AA2B890C3D688C60A4F36B1A2F8 /* FBSnapshotTestController.m */,
+				319F4E219DF8828E32FA4DAE77D513A6 /* UIImage+Compare.h */,
+				282764781C059B0DB57FDACA0C0BB60B /* UIImage+Compare.m */,
+				558025F2AF4CCA6D7D76F2E9708B695B /* UIImage+Diff.h */,
+				D7BDCDB2DEA5D5770412DD6711C714CE /* UIImage+Diff.m */,
+				6F1765C8C3C2398470CECF4BF768BBF3 /* UIImage+Snapshot.h */,
+				CB52DE9A16B2B47581B7590E64B8F1D4 /* UIImage+Snapshot.m */,
 			);
 			name = Core;
 			sourceTree = "<group>";
 		};
-		90CA5BA093CD63012A596FB6DE333F5C /* Support Files */ = {
+		A731B0F5AFECE49E7FE32E30A2AAC5AA /* Nimble */ = {
 			isa = PBXGroup;
 			children = (
-				189C13D561C6C0154E7D6DE283542670 /* Clavier.modulemap */,
-				B52A1D267E4306D38FBC60311C53596D /* Clavier-dummy.m */,
-				B1304AEA4C2A29BDFB0FD334F6D37235 /* Clavier-Info.plist */,
-				E330D5BF283B58CF1B35AF6E8225AB70 /* Clavier-prefix.pch */,
-				4535E8162B56FA4819A46D4475072AEE /* Clavier-umbrella.h */,
-				B0AE796C235D92E193ECAB844FAEC5D7 /* Clavier.debug.xcconfig */,
-				3B9FE67E24DEA883C62DF820B4897052 /* Clavier.release.xcconfig */,
+				DDDEFBBE383CEF0113F6862E05191F60 /* AdapterProtocols.swift */,
+				ABB09A11566CF986AD48C6549F1DF6FE /* AllPass.swift */,
+				F5AC65036D6E9A84860DDA4629635668 /* AssertionDispatcher.swift */,
+				C63FD177C37DDAFDC697F400A9310B45 /* AssertionRecorder.swift */,
+				FB0251F36EC4506C3F07058D0347A9C0 /* Async.swift */,
+				D3D9073747974921B39E2860CB14DA4A /* Await.swift */,
+				C84001CBA62A9367004CD433B640DD2C /* BeAKindOf.swift */,
+				C87B24A186FCDB02CF0D595F18D832BC /* BeAnInstanceOf.swift */,
+				82534E64080EFDF31CE186AC81026BFB /* BeCloseTo.swift */,
+				0E88F2FC6E8CEA8850ED0C105DB2C956 /* BeEmpty.swift */,
+				FE6395A7FC62F1F43D388A1E50BEC558 /* BeginWith.swift */,
+				14AAA70E12E4023B8070CB7B61B0CA10 /* BeginWithPrefix.swift */,
+				CD038515EE39DB69BA1B155638B8190F /* BeGreaterThan.swift */,
+				EA4FDA7E7C2D315873F35637ACF652BF /* BeGreaterThanOrEqualTo.swift */,
+				D31AEA7BA2234939049F20CB527268B2 /* BeIdenticalTo.swift */,
+				BF8EEC9238191C52E8003E1A80A8FE63 /* BeLessThan.swift */,
+				8C1B40929DF06C32BF05A995C0D946F8 /* BeLessThanOrEqual.swift */,
+				A9195138B9659C5A257AB4C60A9C1352 /* BeLogical.swift */,
+				F405A3F6D012E6C95F68E02361A857F3 /* BeNil.swift */,
+				F8FA4E0DFD336AB01E9201A729A56095 /* BeResult.swift */,
+				8E5836EA5E75BBBC12707CDB1CFD6A93 /* BeVoid.swift */,
+				CE60D8EED0C1A735B7454F76E9F57FE0 /* BeWithin.swift */,
+				6AB4B50F8B3B44F718F04C4767E2AA13 /* Contain.swift */,
+				678AF299CA04FAD3698E4BC6CEDE6871 /* ContainElementSatisfying.swift */,
+				DE54E2C190061D03BECB93BB05655AB3 /* CwlBadInstructionException.swift */,
+				537B0813DF8853E15EAB48020BC37C99 /* CwlCatchBadInstruction.swift */,
+				41C92E3B75B8BB489E56022BC5A65376 /* CwlCatchException.h */,
+				3AC7A401831533E22D2F837FEEA21494 /* CwlCatchException.m */,
+				7ACB45BF5DE830982F05C2CDDF953780 /* CwlCatchException.swift */,
+				6B5C17DC79943927CE4CB57CEAFEC047 /* CwlDarwinDefinitions.swift */,
+				2842061E008A78CC6E094CB36C3E247D /* CwlMachBadInstructionHandler.h */,
+				50FBBA947BEE1065C7BE95C98378F011 /* CwlMachBadInstructionHandler.m */,
+				FDCA813B7968AFC1A0F558B7FAA98240 /* DispatchTimeInterval.swift */,
+				D08734FE82D4DFBBA5AE8FF59A8DAF35 /* DSL.h */,
+				42A166E4F28EE1901F0E1F1E24FB54ED /* DSL.m */,
+				D11D5FE18BA090E3D202EF3D5B43DF68 /* DSL.swift */,
+				532A0F77815F32D8E92CAF614C7F79DD /* DSL+Wait.swift */,
+				C05AB360292FB0C7E7FE977451943CF0 /* ElementsEqual.swift */,
+				AA150DEC94AA33CE21F364C2F0148673 /* EndWith.swift */,
+				689EA5A8322AEB80986A7F134CDC2EC2 /* Equal.swift */,
+				1073257FF467D61B3567391C3347261B /* Equal+Tuple.swift */,
+				CD03B9F6E829B557161728E1637C345E /* Errors.swift */,
+				9140C28C0126C157068F8AA51BCBFFBD /* Expectation.swift */,
+				79CD87051B354E1AA997F90BEEE728E4 /* ExpectationMessage.swift */,
+				0B5B452DFE64C3F186B6A229EC15B95A /* Expression.swift */,
+				B77A21B9AA97E3109FA1008506D1ABBB /* FailureMessage.swift */,
+				8DF48F49DD204444B1019B81C975C2EE /* HaveCount.swift */,
+				B10869DBD981C089A89A6A64FE9BFE3C /* mach_excServer.c */,
+				3252F8377525A241629864B054BBAF82 /* mach_excServer.h */,
+				62FD94A9BB3F36AB27646DE937182371 /* Match.swift */,
+				5C18842FCD6A73C7B087A5A9C434C5A2 /* MatcherProtocols.swift */,
+				24C9558AFDB71D8F3CE7422A01AC428A /* MatchError.swift */,
+				061F90FFFFE37ACD40F5493C435EF4BB /* Nimble.h */,
+				6E24FE81A643C5BF30D89D91A5A16CB9 /* NimbleEnvironment.swift */,
+				D8E4A020A29A84C2D3F5D020D8F912C3 /* NimbleXCTestHandler.swift */,
+				8D46B055BA3B982118DA31D58B699444 /* NMBExceptionCapture.h */,
+				A9BE7F0C1BCB6D0C892EE6AB25A63660 /* NMBExceptionCapture.m */,
+				7EEA129A74B9B8ADC38251EA4409F55E /* NMBExpectation.swift */,
+				2FC519DC81C6962CCA4FDA122C485942 /* NMBStringify.h */,
+				7ADFD21EDD7BC59AA71C74FA1EC65EE5 /* NMBStringify.m */,
+				15AEA58696DE01ED099AE800C305E423 /* PostNotification.swift */,
+				2394AADAC17794D0E0F44BE7A3AC9152 /* Predicate.swift */,
+				D9C04209E3093D861761CD3BCE9259C1 /* RaisesException.swift */,
+				375E45F8DE598CC763884C1B61C38C19 /* SatisfyAllOf.swift */,
+				7A3FF6B6B6C9922767CCAE37D2DC3486 /* SatisfyAnyOf.swift */,
+				32A615C5E78ECA75FC96B04D80CDABAA /* SourceLocation.swift */,
+				632A143858BE02B2BE015727F857E8BB /* Stringers.swift */,
+				5D92F4723D78E0860F1944E726237418 /* ThrowAssertion.swift */,
+				6369A57BB4DF6BA0969372DC56D987B4 /* ThrowError.swift */,
+				8F79D8669C7DADB8D9B17B0206628CCA /* ToSucceed.swift */,
+				A554CAFF68A1670E54D9A208FBEAC439 /* XCTestObservationCenter+Register.m */,
+				172A72606E4E558AC489F1DFD22A7775 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../Target Support Files/Clavier";
+			path = Nimble;
 			sourceTree = "<group>";
 		};
-		94C3E15D811A08348435EF596313A0CF /* iOSSnapshotTestCase */ = {
+		AA8DE4074C7752E5395F8991C46B791F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				21164578E956F6C74100D58F0F740125 /* Core */,
-				AAB0DBAF5A049BD5CCC183663779539C /* Support Files */,
-				01D5356265A19D5F4E3EB04741D07DED /* SwiftSupport */,
+				7F97FC61CE6B3F693AC214DF1B2E709A /* Builder */,
+				8A9183C6AE18B232D740888579CB9006 /* Chary */,
+				11BD50A996C4899240193745218FD3EE /* Clavier */,
+				2E6348DB5402F35C5257A1C066D79AC8 /* DiffableDataSources */,
+				F0A15CE0CC76DF4686CB89A25DF1B0AB /* DifferenceKit */,
+				D24DD08D81334C603B9EEE2531CD5E73 /* Draftsman */,
+				0021D78F2D7BBA978AC7D6013A8EC6F3 /* FBSnapshotTestCase */,
+				789BE56AB8615F7DF35919D81FC0B560 /* Impose */,
+				B93DE9F237EE7D0D59BA470C6D628DA9 /* iOSSnapshotTestCase */,
+				A731B0F5AFECE49E7FE32E30A2AAC5AA /* Nimble */,
+				03F60A65A2A7580EEC75BD453CCD2DDE /* Nimble-Snapshots */,
+				37D4297A8B02D3641271A7DB3A429FC1 /* Pharos */,
+				0D6FD5AA3AEB86F58BF6E361081C9E89 /* Quick */,
 			);
-			name = iOSSnapshotTestCase;
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		AACDE9C8C5A4EE5FE5782297ACE4CB6C /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				E42F520E0364DEFA6D20F0D1B2139958 /* FBSnapshotTestCase.h */,
+				2F6108F0CE795ECABEBD357F00D4C740 /* FBSnapshotTestCase.m */,
+				CB97CEF87923E8ACD3BCCFE9CC952D2B /* FBSnapshotTestCasePlatform.h */,
+				50E6CB9489E0FD254CEA852EE8A7CD35 /* FBSnapshotTestCasePlatform.m */,
+				234C2930B6808EBED2EDB3A11CA43505 /* FBSnapshotTestController.h */,
+				3D98D74A637620C3F25F0B45F1D33A60 /* FBSnapshotTestController.m */,
+				5D5C64EC41ADFD2C50C433A33EBF7B13 /* UIApplication+StrictKeyWindow.h */,
+				8A21DD4FFD20C66A685AE00C08503232 /* UIApplication+StrictKeyWindow.m */,
+				184DAF9B26959C4D115DAF1C9B9D0AF7 /* UIImage+Compare.h */,
+				2DA30B0E36FABF4B4BEE94393F7CEFB9 /* UIImage+Compare.m */,
+				B510E77FFC87218687B479FD7EB92A97 /* UIImage+Diff.h */,
+				135204924EA6DD3EDDB271B47C115EBD /* UIImage+Diff.m */,
+				35DD4433D51ABF748525CAE034B6AF2E /* UIImage+Snapshot.h */,
+				9A9B3F5A8D3916FED03F96F0EA8A36DE /* UIImage+Snapshot.m */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		B5BA97729FBDCFD26D9A3F0B338A2445 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				FDE99C0F93E1817DE7EF37940FDD5866 /* DifferenceKit.modulemap */,
+				0698F24649790E50269FB7B7F9E9D775 /* DifferenceKit-dummy.m */,
+				FE3FC4820041E5540F1732B57CC78631 /* DifferenceKit-Info.plist */,
+				E07757421D9121B05540B0D45F20EA93 /* DifferenceKit-prefix.pch */,
+				4C06E3445C4F18D29E68F5DFF3CCF9F1 /* DifferenceKit-umbrella.h */,
+				7BBF38670333C8645413823A58DF3ACC /* DifferenceKit.debug.xcconfig */,
+				9E67858EC04F7B9B2532565C0063852E /* DifferenceKit.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/DifferenceKit";
+			sourceTree = "<group>";
+		};
+		B93DE9F237EE7D0D59BA470C6D628DA9 /* iOSSnapshotTestCase */ = {
+			isa = PBXGroup;
+			children = (
+				8BB973950A2BC2F6D15724C2F31EA95D /* Core */,
+				4D4AABB32BEA85B21E14BFE711DCA8F8 /* Support Files */,
+				1A9528F77C8E07842879A228CCDA7044 /* SwiftSupport */,
+			);
 			path = iOSSnapshotTestCase;
-			sourceTree = "<group>";
-		};
-		9810F0B46396C0E3A2AFC7F42B7EA359 /* SwiftSupport */ = {
-			isa = PBXGroup;
-			children = (
-				B6E31FEE7CFC8305CDDFB9951256A420 /* SwiftSupport.swift */,
-			);
-			name = SwiftSupport;
-			sourceTree = "<group>";
-		};
-		9DFF240E6F5F914D4055C589D258FF9D /* Nimble-Snapshots */ = {
-			isa = PBXGroup;
-			children = (
-				751853C4FFF83D31E6D0792615C3F6E0 /* Core */,
-				D066F34A3F9C09F53CA04E1FB72C20AB /* Support Files */,
-			);
-			name = "Nimble-Snapshots";
-			path = "Nimble-Snapshots";
-			sourceTree = "<group>";
-		};
-		A0427596DDDEBE1B9A0A150079558539 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				03CC20F83553359B1C0A2A26F3882F67 /* Algorithm.swift */,
-				F0B25CDE8AA99BF58EF8602FC867699A /* AnyDifferentiable.swift */,
-				6FE8561F30C072431561A4DCB25891B1 /* ArraySection.swift */,
-				EBA7CFBA8461236442A0AF5BBE8436CE /* Changeset.swift */,
-				764FD06EF0185123816A74099FA09DCF /* ContentEquatable.swift */,
-				65CECF18F545C9F447A05B0E382C439F /* ContentIdentifiable.swift */,
-				51CEFB7928E2BE82AFA4DEC9A9952D72 /* Differentiable.swift */,
-				0782B8A6426FCB4AB4091CB666D25E91 /* DifferentiableSection.swift */,
-				1E0B3185C60C16AE6AF792939B09586B /* ElementPath.swift */,
-				037DB31BFFE1BEB2B9B63504EEF695EE /* StagedChangeset.swift */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		A4D37D43AE78CAA954F1EEEFA31EA59A /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				F768E9892B131E387E44F7738969EE69 /* Chary.modulemap */,
-				A02B633731AF54640C496A77E303336A /* Chary-dummy.m */,
-				86D0AFFD87077DBB90BE1F4457E0AF98 /* Chary-Info.plist */,
-				EC7230FB75733E08AAC833628D32E2CA /* Chary-prefix.pch */,
-				F26A592169A3D35FB26EBA578DBB0198 /* Chary-umbrella.h */,
-				24B83A3AEA7348855B89ABB3FCC6249F /* Chary.debug.xcconfig */,
-				EF4BFE980117902700C14D371B047753 /* Chary.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Chary";
-			sourceTree = "<group>";
-		};
-		AAB0DBAF5A049BD5CCC183663779539C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				ABA56E0304061E7751A73E9233465F0B /* iOSSnapshotTestCase.modulemap */,
-				5E3D399F3A1E2617F98BD948AF3555BB /* iOSSnapshotTestCase-dummy.m */,
-				81FBE2A955107533A9126772B9F980BB /* iOSSnapshotTestCase-Info.plist */,
-				C778224F6D17526D332A1A732D62F6C3 /* iOSSnapshotTestCase-prefix.pch */,
-				D0AE7FB63803E68997653B97A558AC58 /* iOSSnapshotTestCase-umbrella.h */,
-				946A0B6964FAE6494BC5951FA0E9913A /* iOSSnapshotTestCase.debug.xcconfig */,
-				7D324A4C7A3320D7A3B34F8591B04F2C /* iOSSnapshotTestCase.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/iOSSnapshotTestCase";
-			sourceTree = "<group>";
-		};
-		AFF4C7E725722D74BDB778023AF79A3C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				BA41A10C24DA040F16E08E2811ECD51B /* Draftsman.modulemap */,
-				BD32D66C8033157D927794F2158927BC /* Draftsman-dummy.m */,
-				774905AEF7F4E7B36C64127F70355052 /* Draftsman-Info.plist */,
-				B75B41A005271D4586413F73132419A4 /* Draftsman-prefix.pch */,
-				824E2426D17BA9CB5A3CD3DF7A6337D8 /* Draftsman-umbrella.h */,
-				A3AA5F11B867859F29682198585A3A3C /* Draftsman.debug.xcconfig */,
-				48477023D234FAAC61E96CA0555A8495 /* Draftsman.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Draftsman";
-			sourceTree = "<group>";
-		};
-		B2B71955A9051CC64B5A33E968CF93AD /* Quick */ = {
-			isa = PBXGroup;
-			children = (
-				EDA1545D363F12D38D1BD95005098390 /* Behavior.swift */,
-				8D4B3143E105F6047E8E8377A2E8F225 /* Callsite.swift */,
-				9286E4E70459FF4031B156D5D2F4D858 /* Closures.swift */,
-				FCC3E6EF36C612C433233DEA6F14132A /* DSL.swift */,
-				615BC8C141C6F89AE0566E05E73B9E55 /* ErrorUtility.swift */,
-				8D543A275A56B9790A70AB7F4B8F0D17 /* Example.swift */,
-				13C115EB68A03F4967063DB33A5A50AC /* ExampleGroup.swift */,
-				B22FC8E5CBDFF2E5987E05D43ED99C14 /* ExampleHooks.swift */,
-				704F2C4AFEE84BF6378E879AF0E10205 /* ExampleMetadata.swift */,
-				43E0A5C89B7E50AA6958466482117588 /* Filter.swift */,
-				BCA6812B2408C6D670466B1A95C65396 /* HooksPhase.swift */,
-				FD598A36158E3DB804D282D879DDBDA0 /* NSBundle+CurrentTestBundle.swift */,
-				5B0A4E88409BA10522587F165FA92820 /* QCKConfiguration.swift */,
-				213376EA86515B5196B6CEDB20D9339F /* QCKDSL.h */,
-				F22AF64DC2D88452F9112FBEF6160703 /* QCKDSL.m */,
-				8605ED7B5C71FB407B2F6113BA5B6512 /* Quick.h */,
-				DCA253C6F893C7247603F0FCD2CE3586 /* QuickConfiguration.h */,
-				61D212BDC8D8434D70AE6958814A8AF3 /* QuickConfiguration.m */,
-				DF7FDCE302C82F7EC931F92909B1002E /* QuickConfiguration.swift */,
-				6A57D62C8FBDEEDBA8021BF1E4767684 /* QuickObjCRuntime.h */,
-				9B98B8CBA5CFF46374EC365AEC200506 /* QuickSelectedTestSuiteBuilder.swift */,
-				03C82DAC0C57E365D204090849130501 /* QuickSpec.h */,
-				AA0E17F6121AD73BA387D5ECC1267DB6 /* QuickSpec.m */,
-				FF7F6290AF422BA8B8735CE1A1E8EDB2 /* QuickSpecBase.h */,
-				9E9FDD46562F9F6E3E7DA96E32D29012 /* QuickSpecBase.m */,
-				A1DBF26FBAC36C1B04011AFE2E072C52 /* QuickTestObservation.swift */,
-				89B6D072DB73E3F7D011511BE01FD688 /* QuickTestSuite.swift */,
-				27E4AA269DA9667341CBE3776BECBE92 /* String+C99ExtendedIdentifier.swift */,
-				246BBB114D597989D3FD6CBF785BD540 /* SuiteHooks.swift */,
-				4BE5F2D356B1DC3B2AAEAB6F9501BF22 /* URL+FileName.swift */,
-				036911C73F6CEC1C554E5C54D1A3AC05 /* World.swift */,
-				30667DFA8C29A058183C43DA2B15613A /* World+DSL.swift */,
-				0E15091123661BA326ADCE65EEF5C381 /* XCTestSuite+QuickTestSuiteBuilder.m */,
-				1881CB63ECEB969F6DCF901EE2C51C38 /* Support Files */,
-			);
-			name = Quick;
-			path = Quick;
-			sourceTree = "<group>";
-		};
-		B42A2872540D21D3E9929B3B9943153B /* UIKitExtension */ = {
-			isa = PBXGroup;
-			children = (
-				B24855FF78369168A881DFF7C4D8694A /* UIKitExtension.swift */,
-			);
-			name = UIKitExtension;
-			sourceTree = "<group>";
-		};
-		B9A8DD66074A04CF45B1859428E5001F /* Draftsman */ = {
-			isa = PBXGroup;
-			children = (
-				1B7B96FFF648DD539AAF8785422B9038 /* AnchorExtractable.swift */,
-				0F3898660B738CA03CDED30F94DD96A1 /* AnchorPair.swift */,
-				77AE0350F61BF5BCAE1037D76874C50A /* Array+Extensions.swift */,
-				F153ECF4DEE5575D636C2B522BB6478E /* Axis.swift */,
-				B008CAA163FB6520E7093797421AFB23 /* AxisAnchor.swift */,
-				9A9CE90FD78A4F310C33D2FBD8A69297 /* AxisAnchorRelation.swift */,
-				36F4AF68756B46ADEA118A4A0259FFE3 /* ConstraintBuilder.swift */,
-				BBB6922C2FBD9852EE6A94C9D8CADA31 /* ConstraintBuilderRootRecoverable.swift */,
-				92E6797C9FFB372179EB33EA9F090E97 /* Dimension.swift */,
-				1BAA31AC885F0732D60994336F6A1B6C /* DimensionAnchor.swift */,
-				363DE00C624F3969A50A8CEF6082D4D6 /* DimensionAnchorRelation.swift */,
-				1E87CDA7581F7F55BF08764F6EC8ED4C /* Enumeration.swift */,
-				4A5185DD992ED573D51556BF905AEB90 /* IdentifiedAnchorRelation.swift */,
-				E02F56E32697B6FE0C57E60EA9A0D058 /* LayoutAnchor.swift */,
-				467B43AAF430D3A0043CEC7ACEE9BD83 /* LayoutAxisAnchor.swift */,
-				FC6CF17F617DC7102A35F55E3C0E42CC /* LayoutDraft.swift */,
-				B058E81936E33FC8F7675DA75E30323B /* LayoutDraftBuilder.swift */,
-				69F3063851CB50979EFE5A7D230758BA /* LayoutPlan.swift */,
-				A8BBE8B87F291B6B5267E9C7B51F55FA /* LayoutWithAnchors.swift */,
-				9F8C98C269A257389AB4C6E0E29D5221 /* NSLayoutConstraint+Extensions.swift */,
-				93AA2D74F75CB85E9BF0FD6835563CEA /* NSLayoutDimension+Extensions.swift */,
-				467664C80243597EA4403F1CB2686513 /* Pair.swift */,
-				887317B216A4BCCE5DD7F88F40D95831 /* PairAnchor.swift */,
-				3F831D762664684524DA3F196496B5F1 /* PairAnchorRelation.swift */,
-				BB90DAEB2EAB5974F43734AF4AA73E8B /* PairConstant.swift */,
-				4004351F331CDA599C0EE531AE4354E8 /* PlanComponent.swift */,
-				DC731D84A2034B1FA6A066DF0C92A65C /* PlanContext.swift */,
-				1EE68D6488A4E79BA69B9BC1CC29096F /* Planned.swift */,
-				974B5B86B45250B3A6D781BD18FD421C /* PlannedDraft.swift */,
-				E88A4C15CFF2BB4D4B235F25F00A4448 /* PrioritizedAnchorRelation.swift */,
-				A1E7D3B6A6164ACEA24310ED4E59FC4C /* Quad.swift */,
-				2525105B63E6CD74069B8CCCA3E85372 /* QuadAnchor.swift */,
-				E8E45DEFD541A174D2203936603A261A /* QuadAnchorRelation.swift */,
-				A4D8166F31C51BE7D7D67BEAFC4D20A0 /* Single.swift */,
-				18E26B8E68FAB43946B433FDE9715CAD /* SingleAnchor.swift */,
-				AEAC6C2E9E92E355963AD626F25304F5 /* SingleAnchorRelation.swift */,
-				B2156F5872120D784B153AB8C85D2E9E /* SizeAnchor.swift */,
-				66CB24D864E2B9EDE7065C65EB77765F /* SizeAnchorRelation.swift */,
-				BEC878C53567060ED9A38659A3C83CC7 /* StackCompatible.swift */,
-				7547B7B3C8005E3B8079DC61E0651AAE /* TriAnchor.swift */,
-				1CC34CB5D7D09A959721C4D66E80F1C0 /* TriAnchorRelation.swift */,
-				28A12240624413AA73C433E2C28AC1C5 /* TriConstant.swift */,
-				5C0AC4EEB7D237989BF921F123FA80B6 /* Trio.swift */,
-				EC492BC359B3FBBB1C4C190B284F8FE0 /* UIKit+Extensions.swift */,
-				6C22125074FB5EA22E43C2569D5D6780 /* UIView+Extensions.swift */,
-				3B34C0DDAE8494B195F94D39B690D727 /* ViewPlan.swift */,
-				35D1F4421650691693EEE9DCE38DF9B8 /* ViewPlanBuilder.swift */,
-				AFF4C7E725722D74BDB778023AF79A3C /* Support Files */,
-			);
-			name = Draftsman;
-			path = Draftsman;
 			sourceTree = "<group>";
 		};
 		BA4F31F07263C99FC76E66D632A59F09 /* Frameworks */ = {
@@ -1719,19 +1718,49 @@
 			path = Artisan/Classes/Extensions;
 			sourceTree = "<group>";
 		};
-		CE90DE7BF83879D43716540DCE2F0AFE /* Support Files */ = {
+		C223674545AE969F5E123D27811307EE /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C9ECB446D9734A1F12F219FF998C329A /* Impose.modulemap */,
-				238B3705E5F1739794C4528440C69B2C /* Impose-dummy.m */,
-				D01952EFDB1C5D32DBA15CD6044CF0F5 /* Impose-Info.plist */,
-				1A7D66A22E9C852A4AD90CF06FF85E94 /* Impose-prefix.pch */,
-				A9A41D5250027CDBEBCB776BA9E40264 /* Impose-umbrella.h */,
-				7048EAB14F18A05F850568C13C63F3EC /* Impose.debug.xcconfig */,
-				4E00BDD6380CA33853243E54C2A817AE /* Impose.release.xcconfig */,
+				FA68554A5324FF8F9851DA897B8539F2 /* Clavier.modulemap */,
+				E767CD536D9E2EDF469D1D30C0116D22 /* Clavier-dummy.m */,
+				0E8763B81BF79CC14D23ED961EBBDD76 /* Clavier-Info.plist */,
+				458CA75E910B9A310B1E7028A4AD0F2F /* Clavier-prefix.pch */,
+				FC626DACEF42BFBBE329407F595188A5 /* Clavier-umbrella.h */,
+				B8F529B749964D64E300B52A2769199C /* Clavier.debug.xcconfig */,
+				A72EC3090B7CA3658DFDD0773F5DDE0A /* Clavier.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/Impose";
+			path = "../Target Support Files/Clavier";
+			sourceTree = "<group>";
+		};
+		C66BB34B0D26C26AEDA1BDDCF46A569F /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				682649E7A29187C4F4AC2054C6C56E8A /* Builder.modulemap */,
+				8C40F41CC267DEF04A76CE0C47AC8C04 /* Builder-dummy.m */,
+				99D243D76B6B0769ECA2A3FFA81AD3DB /* Builder-Info.plist */,
+				5AB3E94ACBAF641ECBEBFD3020E8FACC /* Builder-prefix.pch */,
+				D347FF5DDE93935EB0D9AC2A16B1FD25 /* Builder-umbrella.h */,
+				0940FBA73024E0A50FBBA91B5FCD776F /* Builder.debug.xcconfig */,
+				05D721F6DDD72B4F022CD7391B84C536 /* Builder.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Builder";
+			sourceTree = "<group>";
+		};
+		C927007CB61F17B83889BB80746C2145 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				1F1ABC9A70534A6A278B07A6545A4B3A /* FBSnapshotTestCase.modulemap */,
+				CD86455E3384C9970EA0E4997A45A3B0 /* FBSnapshotTestCase-dummy.m */,
+				5D18FF4F783101567C65818ADD0AC5FC /* FBSnapshotTestCase-Info.plist */,
+				57855198631521F118E62272838F7932 /* FBSnapshotTestCase-prefix.pch */,
+				D1971CB2689FE21A1FF0F6ABED696EEE /* FBSnapshotTestCase-umbrella.h */,
+				A872E37B3AC6FF303E2FD94E65FC19AF /* FBSnapshotTestCase.debug.xcconfig */,
+				5BE773968DFE2AB171E4732B22BA4372 /* FBSnapshotTestCase.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/FBSnapshotTestCase";
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -1740,25 +1769,10 @@
 				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
 				E455B1519595E76F5F6E951A6EB25D0A /* Development Pods */,
 				BA4F31F07263C99FC76E66D632A59F09 /* Frameworks */,
-				EF1E931FD2B2DEAD0273D8E185E47EC8 /* Pods */,
+				AA8DE4074C7752E5395F8991C46B791F /* Pods */,
 				324DD14115553A78703DC4692F35CF57 /* Products */,
 				16E8F9EF096B3C13E8EA5328523B945C /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		D066F34A3F9C09F53CA04E1FB72C20AB /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				FFB70EC31BF10704DE935C13FC7E6791 /* Nimble-Snapshots.modulemap */,
-				124233F04C4A8ED9D924A69B7661ED74 /* Nimble-Snapshots-dummy.m */,
-				DAC074DF26EB98CE65AC54A0CC6AFC70 /* Nimble-Snapshots-Info.plist */,
-				20050F8836F0D81C306516FA337881B7 /* Nimble-Snapshots-prefix.pch */,
-				C6F53C998FB56DF28EC9D4E0228A4C06 /* Nimble-Snapshots-umbrella.h */,
-				B512C78E55A90354D479A1DA348A1184 /* Nimble-Snapshots.debug.xcconfig */,
-				6B731C52788415156A8F37A1F6B32281 /* Nimble-Snapshots.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Nimble-Snapshots";
 			sourceTree = "<group>";
 		};
 		D1EBE331F75D6C897FECFE4C7340C257 /* iOS */ = {
@@ -1770,6 +1784,76 @@
 				14D785D4B5B0581702FEB63D26E7C45E /* XCTest.framework */,
 			);
 			name = iOS;
+			sourceTree = "<group>";
+		};
+		D24DD08D81334C603B9EEE2531CD5E73 /* Draftsman */ = {
+			isa = PBXGroup;
+			children = (
+				4580972A7EE536DDC3991BA43667E65E /* AnchorExtractable.swift */,
+				5B32C665DB63D5618BEA62D30CBBA8E9 /* AnchorPair.swift */,
+				23D7AFC5E1DB6380FD96D386996C7522 /* Array+Extensions.swift */,
+				A8FF02CC4458AFD25F8A0B0713C6F14C /* Axis.swift */,
+				B7BBB227EDBB7BFA05AC77D1BABA6987 /* AxisAnchor.swift */,
+				8869248C4992F8BE4A115183C02FDC34 /* AxisAnchorRelation.swift */,
+				C4A3A9585BA13997F71FD9AD9D380431 /* ConstraintBuilder.swift */,
+				6572DD077B69C33A0869ADB1F914861F /* ConstraintBuilderRootRecoverable.swift */,
+				DB08AC89A4D792FE11A42B075CCB7B02 /* Dimension.swift */,
+				3E2D13FB9F1CF20CAE868B0FEDF63123 /* DimensionAnchor.swift */,
+				1AC23AE382126E4156635A2A5203DEF4 /* DimensionAnchorRelation.swift */,
+				09A2F81F85C9B07EECF3F60C28D3A732 /* Enumeration.swift */,
+				4C78966D39E8E662EDE0E59F01DBFC43 /* IdentifiedAnchorRelation.swift */,
+				5DA8297BEC6EF6CDD2277BD12B197448 /* LayoutAnchor.swift */,
+				EA849E7083368971A58B897F06ECF4FB /* LayoutAxisAnchor.swift */,
+				CA2D2533E4A629D636BF9B8287DC344C /* LayoutDraft.swift */,
+				3CCAF70F682FDCBD18B53CD120AE86CB /* LayoutDraftBuilder.swift */,
+				421F80C00CEFC13B1384C59BBD8A2E49 /* LayoutPlan.swift */,
+				D561B067E876E7BE7C6A544A3D2873DB /* LayoutWithAnchors.swift */,
+				09755CE44B8C954939385A3A1DD4C771 /* NSLayoutConstraint+Extensions.swift */,
+				28343404E01E6903FA61C3346662FEE1 /* NSLayoutDimension+Extensions.swift */,
+				9AF8BFBA4E507571D049BE7F9A610726 /* Pair.swift */,
+				883A0229A960E1F7517BE56CCFFE0E3B /* PairAnchor.swift */,
+				B42D68D42B8EE5678A3B39A958F654E9 /* PairAnchorRelation.swift */,
+				F2966097444B6FDBDAB00AE88274B640 /* PairConstant.swift */,
+				1CE9E9D3B34CE0AC817D6BDF956C2532 /* PlanComponent.swift */,
+				E4E197AE0F4FD3E9A3C44B1AF8AE1FC3 /* PlanContext.swift */,
+				A32EF1E24A7F314B050CF9DB5EEFFE62 /* Planned.swift */,
+				F59850663F6808953A081C401EE7FC99 /* PlannedDraft.swift */,
+				8D4220988B6F1501CF122C8127F73416 /* PrioritizedAnchorRelation.swift */,
+				177D1E3CC6CE47EED4125A8CCA49A4A9 /* Quad.swift */,
+				989AABAEE0CC5902F8A5E26BBD7B36A7 /* QuadAnchor.swift */,
+				73655E683AB52450A1CA90262E8A05CD /* QuadAnchorRelation.swift */,
+				040865FA34F88378DC68B67D4B6F39B1 /* Single.swift */,
+				44AE95E5F5D1D0E395A6DBDCACAEFA2F /* SingleAnchor.swift */,
+				77127953399AB2C7DA555E1F602A82E0 /* SingleAnchorRelation.swift */,
+				1BA0D995518747C79A23B7B4B85A43F4 /* SizeAnchor.swift */,
+				4868EF6D73C9BECA98DE6E7824EF7F70 /* SizeAnchorRelation.swift */,
+				7F5706ABA08EAE92689544B4A57E2BF8 /* StackCompatible.swift */,
+				128133987354DBF367D15981472ED297 /* TriAnchor.swift */,
+				0D384368372E08215C8C7F1658F875ED /* TriAnchorRelation.swift */,
+				AE502FA68628C7C40494651F4E477BC9 /* TriConstant.swift */,
+				F4B6A6775A20D152B793ABE6068A8011 /* Trio.swift */,
+				61ED5ED8415D32B291E1BC644D71952E /* UIKit+Extensions.swift */,
+				B340E7679E814ABA2670F1BCD6D63862 /* UIView+Extensions.swift */,
+				6B7629630622DA71E4B7D0AFD598B206 /* ViewPlan.swift */,
+				D4BB5A352F71AA65CF099E08BE7E4A8E /* ViewPlanBuilder.swift */,
+				6675D4C5D9180CA3A8B2E1432A67CC74 /* Support Files */,
+			);
+			path = Draftsman;
+			sourceTree = "<group>";
+		};
+		D253880E53498D7C7E1F1B44B0890D27 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				885CBCD48419B456B584D2EB5B8C01C7 /* Nimble-Snapshots.modulemap */,
+				F4E83BC7353540CCD32305C6D5C33455 /* Nimble-Snapshots-dummy.m */,
+				4019D69E26028750627268554B9EA028 /* Nimble-Snapshots-Info.plist */,
+				13A1B7C72E9CE00F396F3B17812A4BFF /* Nimble-Snapshots-prefix.pch */,
+				D0A251C16525E043B5843A049F091676 /* Nimble-Snapshots-umbrella.h */,
+				B56A0F234860DAE5EDB3A1E1A9AC8539 /* Nimble-Snapshots.debug.xcconfig */,
+				5229633E4CDE069F5A7E47E563E10F22 /* Nimble-Snapshots.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Nimble-Snapshots";
 			sourceTree = "<group>";
 		};
 		D439752BB35DCAD173F40C79138149D2 /* ContainerContentsBuilder */ = {
@@ -1806,23 +1890,7 @@
 				084FFDD67F09953C61F3564D458239A4 /* LayoutDraft+CellCompatible.swift */,
 				02CDA004F5DCA53CEA3A5163B7D49A7B /* Section.swift */,
 			);
-			name = CellCompatible;
 			path = CellCompatible;
-			sourceTree = "<group>";
-		};
-		DDA49D0A03D98E3068B74B74212DBDB0 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				01FC711EAA2ACCCC3713CC3206F16BD7 /* DifferenceKit.modulemap */,
-				0DD5047B5EE6841E39808E4DFCFF3921 /* DifferenceKit-dummy.m */,
-				78A405D063F46996923F534D8CEBF239 /* DifferenceKit-Info.plist */,
-				F679F3EBCD348BA01CD5ED5479CEF1F5 /* DifferenceKit-prefix.pch */,
-				FE22E1954325C34D83FEAB162FACF4F1 /* DifferenceKit-umbrella.h */,
-				83D7F72D0D89433A0A38899D2491842E /* DifferenceKit.debug.xcconfig */,
-				13FFBC3C3BAA8B2193C0EA67D52B6BCA /* DifferenceKit.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/DifferenceKit";
 			sourceTree = "<group>";
 		};
 		E455B1519595E76F5F6E951A6EB25D0A /* Development Pods */ = {
@@ -1850,147 +1918,47 @@
 			path = "Target Support Files/Pods-Artisan_Example";
 			sourceTree = "<group>";
 		};
-		E63B1EA6DC6D437F5E92E7254918EBB4 /* Pharos */ = {
+		E563CF4F0E2F1D90F2D511AE4333D51F /* SwiftSupport */ = {
 			isa = PBXGroup;
 			children = (
-				88C6BB2302184FCDDD2766D6A1A9AE2C /* BaseProtocols.swift */,
-				1476E7577E62B4414BF94FBDD6317E72 /* BindableCollection+TextInput.swift */,
-				C471E1764F3776F488CC7D21C35E30E0 /* BindableCollection+UIButton.swift */,
-				AFF97B906871DDA288C4841F5BC888DE /* BindableCollection+UICollectionView.swift */,
-				E029DF35EBE516108FDF15D219ECFD9F /* BindableCollection+UIControl.swift */,
-				0602AEAB65BA2C712609045B5AF61512 /* BindableCollection+UIImageView.swift */,
-				5B9940116E1153DACAD38FA9A34C30A9 /* BindableCollection+UILabel.swift */,
-				B09FFF38275C1AF9EA37D19C8CC0F1C5 /* BindableCollection+UIScrollView.swift */,
-				50932CBD0F89EC874A1D690E202EFF00 /* BindableCollection+UISlider.swift */,
-				92433D9F3EF6CCA6F3069239BFDCE84C /* BindableCollection+UIStackView.swift */,
-				4BB0BF618D589C9E452FBDD4532270B8 /* BindableCollection+UIStepper.swift */,
-				6BA07CF6F10CF589A79C080EF0A97BA3 /* BindableCollection+UISwitch.swift */,
-				F9AD8F885C2D2573BE89E22A8E0944B7 /* BindableCollection+UITableView.swift */,
-				BC847D7774E3F23D2B7570E7967F34C4 /* BindableCollection+UIView.swift */,
-				ADF99BE5AAAFF13F299321082FDA0EB0 /* BindableCollectionCellView.swift */,
-				7BB8F4FD65984DA69BB3B7FA10CECF21 /* BindableKVOObservable.swift */,
-				E562708482BF2EB6CEDE447CACD70964 /* BindableObservable.swift */,
-				E6345CAC4261F3B0CCC919B0A608CC2E /* Changes.swift */,
-				D0B8D6B4BB1FC7844650895AFA34C70C /* Dictionary+Extensions.swift */,
-				C3DDE4C1C61A71B532678AF658A1DF0B /* FilteredObservable.swift */,
-				013F337C417F599D11D7E1AA46A57DED /* MappedObservable.swift */,
-				2A05905564051BFAA696F2E24B322369 /* MergedObservable.swift */,
-				8B11432EA47C88167C2BA72B5E702DF4 /* MulticastObservable.swift */,
-				8FF36F5D0CE99E6FC7261A5575530B30 /* ObjectRetainer.swift */,
-				6843374F3B004144301DCBA87669EFC6 /* Observable.swift */,
-				73AA1B343A02AE3F34FDD51FCFA8E697 /* ObservableBlock.swift */,
-				1BEC56B47AF0597C3979BD00CC0348ED /* Observed.swift */,
-				7BFE1652DFB1A6C20E2E725000E8B0E6 /* PharosContext.swift */,
-				48F7B317972059C369AFE5379DFDB5A3 /* PopulatedRelays.swift */,
-				FF30E9C5AEB4917A133334A432B35F3E /* Publisher.swift */,
-				166ADDACFA37CB20B20D7C17BFD3270B /* RelayInvoker.swift */,
-				4B76772AB1A7281813E7595D579C25F2 /* Retainer.swift */,
-				96A621B1EEB47FDD39E44D89BBFD664B /* RootObservable.swift */,
-				B204267D3B8FD83A3EFB617F91FC32DD /* Subject.swift */,
-				8B7799AC50C7A6F401D098E78235EB77 /* Support Files */,
+				BFED2A450807A45060E592F222CF4FD5 /* SwiftSupport.swift */,
 			);
-			name = Pharos;
-			path = Pharos;
+			name = SwiftSupport;
 			sourceTree = "<group>";
 		};
-		EA8DC365052AC3CCB992F2C4650BFADC /* Support Files */ = {
+		EA1CCB7F6F486A5E9E3119E072FB2505 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				3B92B6564DCA562E269CE0F36AC7FA45 /* DiffableDataSources.modulemap */,
-				866D90BA278E42189EEDB2D2FBB39964 /* DiffableDataSources-dummy.m */,
-				993C9E844CE806EB028E36519B018B27 /* DiffableDataSources-Info.plist */,
-				12A49B1B2813B889E151F3B10563EEE0 /* DiffableDataSources-prefix.pch */,
-				4FA619C6BFEE11975D4BD6CA70F7623E /* DiffableDataSources-umbrella.h */,
-				A8E54C170A37B2E5EDAE907822146532 /* DiffableDataSources.debug.xcconfig */,
-				BC7E005E09BE55303F395B5D9AA51835 /* DiffableDataSources.release.xcconfig */,
+				1B4DEA5FAA7ACBB2EC4756322C322E3D /* Pharos.modulemap */,
+				007FEAF3D19E5FEF79EF3B667F04CD9B /* Pharos-dummy.m */,
+				83D3927C9DDD1E4A603F8CAD3783B0E5 /* Pharos-Info.plist */,
+				B9FC95A057FAFB6146B3737C52662B5D /* Pharos-prefix.pch */,
+				541FA35F2A62EF0A9C0304AD7C4CC98C /* Pharos-umbrella.h */,
+				D924A3A8B68F65410643D92C4DA11140 /* Pharos.debug.xcconfig */,
+				6B2F30EDF3E8E72C7722AB25C8483656 /* Pharos.release.xcconfig */,
 			);
 			name = "Support Files";
-			path = "../Target Support Files/DiffableDataSources";
+			path = "../Target Support Files/Pharos";
 			sourceTree = "<group>";
 		};
-		EDD7AEBF869A06A55D0B65935B26B220 /* Clavier */ = {
+		F0A15CE0CC76DF4686CB89A25DF1B0AB /* DifferenceKit */ = {
 			isa = PBXGroup;
 			children = (
-				F2484281E8798BEB07CCB1F592A21BF8 /* ClavierLayoutGuide.swift */,
-				5F3AFC1B1E1786D2FB423F613E03C250 /* Extensions.swift */,
-				C2114A1DC41AF49A90D10FD82496E21F /* SafeAreaKeyboardLayoutGuide.swift */,
-				90CA5BA093CD63012A596FB6DE333F5C /* Support Files */,
+				0A1FADD1BEFF11C1937F3A171DFA50CE /* Core */,
+				B5BA97729FBDCFD26D9A3F0B338A2445 /* Support Files */,
+				6E1FD2DD659F84E021BD1BEC953333D8 /* UIKitExtension */,
 			);
-			name = Clavier;
-			path = Clavier;
-			sourceTree = "<group>";
-		};
-		EF1E931FD2B2DEAD0273D8E185E47EC8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				360CF694B296E31D0A930197348100DD /* Builder */,
-				17E1533CB3BB71069ACBBDEAA8ED8B84 /* Chary */,
-				EDD7AEBF869A06A55D0B65935B26B220 /* Clavier */,
-				2285240D773A7B892B3325C594377CF1 /* DiffableDataSources */,
-				F381D00D0B3A056B6B5E6165AB9B2692 /* DifferenceKit */,
-				B9A8DD66074A04CF45B1859428E5001F /* Draftsman */,
-				2845860D4982456777055DEA6B6369EF /* FBSnapshotTestCase */,
-				15B15ED6ABC465F993B6283F2ED50F93 /* Impose */,
-				94C3E15D811A08348435EF596313A0CF /* iOSSnapshotTestCase */,
-				3BF2142D05B26F70741DF3DBCE73C427 /* Nimble */,
-				9DFF240E6F5F914D4055C589D258FF9D /* Nimble-Snapshots */,
-				E63B1EA6DC6D437F5E92E7254918EBB4 /* Pharos */,
-				B2B71955A9051CC64B5A33E968CF93AD /* Quick */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		F381D00D0B3A056B6B5E6165AB9B2692 /* DifferenceKit */ = {
-			isa = PBXGroup;
-			children = (
-				A0427596DDDEBE1B9A0A150079558539 /* Core */,
-				DDA49D0A03D98E3068B74B74212DBDB0 /* Support Files */,
-				B42A2872540D21D3E9929B3B9943153B /* UIKitExtension */,
-			);
-			name = DifferenceKit;
 			path = DifferenceKit;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		0159EEF31701F8AE3F38925C5108B8E9 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B24A21FA385D27663802BB59FB33F503 /* Pharos-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		07ED8083C198AA9033FAB4214D292680 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				91E226CE9A95EF5443941448BC1E23AF /* DifferenceKit-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		0ABF13F2242FA22ECBD967A19084FCBD /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				8984658E81D88C409A99362B5230A28F /* Pods-Artisan_Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0C14FDB42BC164C1257ADCD971540B20 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2BF384A4B734049BE048B3B602A11261 /* Clavier-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0F132A43A5744FE0EE8C7F6F5FF9F8D2 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2DA1A22BA212AB23D226858CE8A81D4E /* DiffableDataSources-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2009,19 +1977,57 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2F00DC6E544409D52FE1656C5A5EE0ED /* Headers */ = {
+		3F6FE36B06FB8E4E7DB4697433EA43A4 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E02E2D468B5505FC0FCD7651FCE7DC44 /* Builder-umbrella.h in Headers */,
+				DE8FE7A30841D2B565F3B1EB2EE265B9 /* Chary-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8E7A83C690C4776129D6148420E3558E /* Headers */ = {
+		4D790DAC19346E9890014CA6E05CCE4B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CE12EB0301C60FD5519BCD9430DE549 /* Draftsman-umbrella.h in Headers */,
+				6C78BC97577569F36E3AA230AE569E42 /* DifferenceKit-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		561AAE6EF519BFDEB1B12F9212692AA7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82AAFF3107CB22DCD981D8A53C908667 /* Draftsman-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		627362F891B16C5384CBD30A32DA1A7D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				42B1A1351CC667E3987738DE8E6550C0 /* Builder-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65BB76EB7B7822E79F8795719C623916 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EEE381DB3D330E2E2A9196DDEB537E40 /* FBSnapshotTestCase.h in Headers */,
+				3780CBA3F5B178B95A9845539332C2D0 /* FBSnapshotTestCasePlatform.h in Headers */,
+				5A7CE55AB8400FD6DF4E54196DDF32D5 /* FBSnapshotTestController.h in Headers */,
+				18C2744F13C3BF9010948AED6A237C62 /* iOSSnapshotTestCase-umbrella.h in Headers */,
+				89005B1F94507D14AC56F261650F92D4 /* UIImage+Compare.h in Headers */,
+				AE9C841FA505A53F5C2B51568C857C8C /* UIImage+Diff.h in Headers */,
+				C4E944A897A01FAB13D82934AC075A57 /* UIImage+Snapshot.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		775353AA66DA014F5AD516D313C408B4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9769029E1F88EC467172B799326B4F8E /* Pharos-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2033,20 +2039,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9ABB1FB8EE66259EE02EF1D80F08EAF6 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6DB21625B845EE64783C837C0E4C2705 /* FBSnapshotTestCase.h in Headers */,
-				A7B8523A43C3DE4FFEBC4165C2FB0291 /* FBSnapshotTestCasePlatform.h in Headers */,
-				41CF42B7D076E0946208103109E70265 /* FBSnapshotTestController.h in Headers */,
-				4F175C4035DA2C1897D706C6CDC06674 /* iOSSnapshotTestCase-umbrella.h in Headers */,
-				EC6CDB60BA96BB0ABF51ED46458F59AE /* UIImage+Compare.h in Headers */,
-				F46E9B84622B2E579E206F844194FABC /* UIImage+Diff.h in Headers */,
-				1D36043A36DAD2DAD85E9888A979828D /* UIImage+Snapshot.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		AD291CBA7F25CD4423FB4C450D16BFF3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2055,11 +2047,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B6BFDF20457648B9578CBB95A1FF3263 /* Headers */ = {
+		B0786C1CDFDC5E220EB9F7EC936EF03A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				58853A4B2909E54FFAAD0F763B294E85 /* Chary-umbrella.h in Headers */,
+				1D6A75C401E567E3620D3A3D768C55C2 /* DiffableDataSources-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2094,6 +2086,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				794C927A15C31A2CC45F9ECF7D512AF4 /* Artisan-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCECBB492521566ED16569FD3D7A296D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E44F8A3CE8B7C40AE873F890AEC6C7B4 /* Clavier-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2134,17 +2134,17 @@
 		};
 		0DED92290FC5B4F771B42870DB0A2D55 /* Pharos */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6B4BD029EDFAD5A11C711A27E086DBA9 /* Build configuration list for PBXNativeTarget "Pharos" */;
+			buildConfigurationList = 4659B122399010D6262791BEFAA4B96E /* Build configuration list for PBXNativeTarget "Pharos" */;
 			buildPhases = (
-				0159EEF31701F8AE3F38925C5108B8E9 /* Headers */,
-				B0EDB69C97A90159FF1806ADE3A118B5 /* Sources */,
-				3D49B5F839F172F7F777E688B03A83D2 /* Frameworks */,
-				9C52AADBEA4B2AD03BD4B57ED5626DFE /* Resources */,
+				775353AA66DA014F5AD516D313C408B4 /* Headers */,
+				8B44C5FAEB80053751A2E9CDFE38621B /* Sources */,
+				016E6AD32F91DE08EE13F320848C2CA2 /* Frameworks */,
+				4D36EA6EB43C62895258B00F3DE679A3 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				D53C15FB96FA249B0CB8A960746B7C79 /* PBXTargetDependency */,
+				5C484E93931C3E028C5AF13945A4E414 /* PBXTargetDependency */,
 			);
 			name = Pharos;
 			productName = Pharos;
@@ -2153,17 +2153,17 @@
 		};
 		222C9BA9370230B670273F42B5E7F810 /* DiffableDataSources */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6F8C3841CBC672AD2CA59FF33EA5410E /* Build configuration list for PBXNativeTarget "DiffableDataSources" */;
+			buildConfigurationList = 2C0ABECBE49CE4DC34A61870679CE1FD /* Build configuration list for PBXNativeTarget "DiffableDataSources" */;
 			buildPhases = (
-				0F132A43A5744FE0EE8C7F6F5FF9F8D2 /* Headers */,
-				BDF62482F2113E46804B2A81FFB5C4D9 /* Sources */,
-				BF10931469DAF8D693EF6781FDD83254 /* Frameworks */,
-				185B030FC939AD85A448F5B02AA405E5 /* Resources */,
+				B0786C1CDFDC5E220EB9F7EC936EF03A /* Headers */,
+				1A780F7DEF58A6F1EC882601AD7BC330 /* Sources */,
+				97E4860462D3B341271EF605DDE42A83 /* Frameworks */,
+				E998E7EBC69FE2018F2953F7594E804A /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				4B684637E1D1DB26BB4B8BD445162032 /* PBXTargetDependency */,
+				01BE9D940237F72462BE78BB50E94290 /* PBXTargetDependency */,
 			);
 			name = DiffableDataSources;
 			productName = DiffableDataSources;
@@ -2182,12 +2182,12 @@
 			buildRules = (
 			);
 			dependencies = (
-				8DBDBCE830653DF7F29E425E9DBA81AE /* PBXTargetDependency */,
-				5FD671EFC527C5D6C11F538BA4DC7E35 /* PBXTargetDependency */,
-				E098B94DE510B3F53A54E960F873BF79 /* PBXTargetDependency */,
-				818C2030320E3A76D6B42B42BD22EB08 /* PBXTargetDependency */,
-				34FB332E56F256B442B73E3B5BA5AE2D /* PBXTargetDependency */,
-				6C15B350CA39AE6F98A79C6D98B43CAA /* PBXTargetDependency */,
+				01E322EB23222747959C972AECDF48FB /* PBXTargetDependency */,
+				32CF5171AB7BA4CDB118E3200D9EE986 /* PBXTargetDependency */,
+				80E9ED7D99C3AA0BEA9826EBC28E1AB7 /* PBXTargetDependency */,
+				F2B49146A3503FE13BBEF39FAA0892D3 /* PBXTargetDependency */,
+				B7613C002909264A75CE3860A3EAF790 /* PBXTargetDependency */,
+				95750BFAB2770255C93B4C6C24FA7938 /* PBXTargetDependency */,
 			);
 			name = "Pods-Artisan_Tests";
 			productName = Pods_Artisan_Tests;
@@ -2206,15 +2206,15 @@
 			buildRules = (
 			);
 			dependencies = (
-				E43A16FA7F89D858359C45F25E6FBF9C /* PBXTargetDependency */,
-				5EA0FA8A4B492D566C73187025589D0A /* PBXTargetDependency */,
-				B25D17765D18E3EF7A1243C6F56751A1 /* PBXTargetDependency */,
-				E905106CDB1EB0B883495615F83ED435 /* PBXTargetDependency */,
-				C02B1999C7ECD17ABE7FAFB452BC8106 /* PBXTargetDependency */,
-				E667E2E52BA9D12EDD4494B13517F440 /* PBXTargetDependency */,
-				87664F465470ECDBAFE0A8D2F8B146F8 /* PBXTargetDependency */,
-				89777068F344848573143C5629E8EDCF /* PBXTargetDependency */,
-				95D4890FB7D9F127534D00C8EC50CF62 /* PBXTargetDependency */,
+				BB6F9342C4083B4AAE9390439011515C /* PBXTargetDependency */,
+				392ECC40386E21738C93795C2598CF24 /* PBXTargetDependency */,
+				A3797D01916CF98F55C6B712D2982395 /* PBXTargetDependency */,
+				3D47D9C845592DF8AD31E591DC8863F3 /* PBXTargetDependency */,
+				A7412B1A142ADF06B1BFACAEC33F2A76 /* PBXTargetDependency */,
+				2CDACDBF90492629D162D67394BA5A84 /* PBXTargetDependency */,
+				31E98164A7CC577EDC385E6B286097CF /* PBXTargetDependency */,
+				927EE8EF5E5D4542F18DF6D20FC2CBAB /* PBXTargetDependency */,
+				3539F2BD308AF59CD097062A1CA2D688 /* PBXTargetDependency */,
 			);
 			name = "Pods-Artisan_Example";
 			productName = Pods_Artisan_Example;
@@ -2223,18 +2223,18 @@
 		};
 		6A3AC2D6739DCB3DEBEB81CF81B207F2 /* Draftsman */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 224B5A32D8429D4FCFB5B168F2F28ED7 /* Build configuration list for PBXNativeTarget "Draftsman" */;
+			buildConfigurationList = B3D81A1CC4D1FA0D854FCD55DA0133D7 /* Build configuration list for PBXNativeTarget "Draftsman" */;
 			buildPhases = (
-				8E7A83C690C4776129D6148420E3558E /* Headers */,
-				6A453F628BBCF73EFFDB4EB46B54E9EF /* Sources */,
-				3B5EF4C1572DD270B74E93C3DB0776B6 /* Frameworks */,
-				DB48A5F7598109A057F10FE669B2786B /* Resources */,
+				561AAE6EF519BFDEB1B12F9212692AA7 /* Headers */,
+				A8ABED0585F83AAD0AD5D0963241C5E4 /* Sources */,
+				F20C10D9C2A9819069790D6A2FC66A21 /* Frameworks */,
+				08208358CDD4D535318A465FC8AA88FF /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				4CE7547275D2E2FEE576C169F2ECF319 /* PBXTargetDependency */,
-				04CE65B0EEFDA29480D48E779B923160 /* PBXTargetDependency */,
+				613A0A2634FBBFECFD4A7FAF7A4BAD5E /* PBXTargetDependency */,
+				2A0F94059E4EA0A41943012DF587A59A /* PBXTargetDependency */,
 			);
 			name = Draftsman;
 			productName = Draftsman;
@@ -2261,12 +2261,12 @@
 		};
 		8FC6E51285E4FD828A61BEFD2100CD64 /* DifferenceKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2FABE7B848A61FDE56023FE40476971B /* Build configuration list for PBXNativeTarget "DifferenceKit" */;
+			buildConfigurationList = 25CB2DD70DEF4041BF1FE2733DBC58BC /* Build configuration list for PBXNativeTarget "DifferenceKit" */;
 			buildPhases = (
-				07ED8083C198AA9033FAB4214D292680 /* Headers */,
-				BFC39C50068DB72A49350D1D3FF6ED03 /* Sources */,
-				613100E04C39CCCE79287D635FF8EFB7 /* Frameworks */,
-				E652A384B68FA0580935A74296070630 /* Resources */,
+				4D790DAC19346E9890014CA6E05CCE4B /* Headers */,
+				2E35B67B7CA82CF0C0CA4E038494165E /* Sources */,
+				A43E82E45E34A3CC43778BAAEC650E14 /* Frameworks */,
+				C10834EA848E9297E564D74BD09D1881 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2297,12 +2297,12 @@
 		};
 		A0746DCD7C48E9F6BAB723766294323A /* Clavier */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1442DC57970F4732D69AD627D656E157 /* Build configuration list for PBXNativeTarget "Clavier" */;
+			buildConfigurationList = 1ED308B9F593B904DBC11065BE23FC91 /* Build configuration list for PBXNativeTarget "Clavier" */;
 			buildPhases = (
-				0C14FDB42BC164C1257ADCD971540B20 /* Headers */,
-				7A30C79560203C89F07EFB803A0D1A1E /* Sources */,
-				7BC9AD4AA92A00DD4BA109C62529B3C8 /* Frameworks */,
-				1E5E12160907B8C2045D575F159F2FA4 /* Resources */,
+				DCECBB492521566ED16569FD3D7A296D /* Headers */,
+				700EB9AEF64153938A1D77AB9EB4A0F5 /* Sources */,
+				D5705338E523DC84F3BBF86E03B6E7EC /* Frameworks */,
+				390D339FBE89A0CE5E1B942A597B4CE6 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2315,12 +2315,12 @@
 		};
 		C393038B0BEF088C1B93E6528005862D /* iOSSnapshotTestCase */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4029556E7594F75B17BF38F4ED9593B9 /* Build configuration list for PBXNativeTarget "iOSSnapshotTestCase" */;
+			buildConfigurationList = AEA4353485BC63226C545B91E035F1B6 /* Build configuration list for PBXNativeTarget "iOSSnapshotTestCase" */;
 			buildPhases = (
-				9ABB1FB8EE66259EE02EF1D80F08EAF6 /* Headers */,
-				B6785B35E438B18B74FA280DCB1D1951 /* Sources */,
-				42085866F9B787834A893F15D17CC58F /* Frameworks */,
-				64F5CF5B5D554A09754D61170C112655 /* Resources */,
+				65BB76EB7B7822E79F8795719C623916 /* Headers */,
+				A7F6BDE61B11C23E910B73F71762F806 /* Sources */,
+				E54B861B69C914F2CA365135A650C184 /* Frameworks */,
+				436C9C7C13D3A19686C25EFA55729A13 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2361,10 +2361,10 @@
 			buildRules = (
 			);
 			dependencies = (
-				7D7C6AB1B9F24EFE11A98A3B0DD4E78F /* PBXTargetDependency */,
-				1C3A98138C988AEDAE62487B98E174D2 /* PBXTargetDependency */,
-				24B7AC682016E67EC8DC72A645848C7C /* PBXTargetDependency */,
-				23BFC76C865622EB9FF5E1953AE4AF8A /* PBXTargetDependency */,
+				FC64E791B39BAB9A7A95F3392B52F962 /* PBXTargetDependency */,
+				7C87FE82FC361B39727A74F731D0971B /* PBXTargetDependency */,
+				3D0182BC7E8F03B3B7B823D066759ED5 /* PBXTargetDependency */,
+				1A9D11D91A5B261FE69111B4C97424D1 /* PBXTargetDependency */,
 			);
 			name = Artisan;
 			productName = Artisan;
@@ -2373,12 +2373,12 @@
 		};
 		E4D0DCAA1CEF50B24DB0FE6DB58A775E /* Chary */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 26E7C0E7F2E9E4583CC946AAA36104D5 /* Build configuration list for PBXNativeTarget "Chary" */;
+			buildConfigurationList = 6D06C0203D713E6308051953612686D3 /* Build configuration list for PBXNativeTarget "Chary" */;
 			buildPhases = (
-				B6BFDF20457648B9578CBB95A1FF3263 /* Headers */,
-				4DC16C1ADD49486DB3B63C4197D574D5 /* Sources */,
-				24B2B92D592F46D7821FCFB918D6D2B8 /* Frameworks */,
-				E402980A445D5B60835F0362114CADB8 /* Resources */,
+				3F6FE36B06FB8E4E7DB4697433EA43A4 /* Headers */,
+				46694EF8DF5E5344CF7E10A08C4DB757 /* Sources */,
+				BD7B51ED06C47FC6FC80B67286EA8B38 /* Frameworks */,
+				454A8E9BD3DCDE2DDBF618B3A788BDFA /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2391,12 +2391,12 @@
 		};
 		ED7AB6873A9DA430A18E0109776D3707 /* Builder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8CBD34B703B7108BE74EB4B8E330DC12 /* Build configuration list for PBXNativeTarget "Builder" */;
+			buildConfigurationList = B3A5B60F7F4061F2BE04D255F0A9E48B /* Build configuration list for PBXNativeTarget "Builder" */;
 			buildPhases = (
-				2F00DC6E544409D52FE1656C5A5EE0ED /* Headers */,
-				7A497E33DCFA844E3278B209C379B896 /* Sources */,
-				07BD1411575C5FF2BA02A4C3AC08F8AF /* Frameworks */,
-				2EFC5067985A8C19BC6A6466962C0480 /* Resources */,
+				627362F891B16C5384CBD30A32DA1A7D /* Headers */,
+				8340E3FC424F641AA566C23219F58710 /* Sources */,
+				27C7239029E8ABC8A3AE7B993549F1C9 /* Frameworks */,
+				25DF49B1DEFF3CC6D4EE0E603055C5D1 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2419,8 +2419,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				C489F4CCBAAFF50691F802F58A972035 /* PBXTargetDependency */,
-				31F01DA61D5E4A89B5BD504E83A1F38A /* PBXTargetDependency */,
+				8B8AFE15C44232E9D3234CDBB9B32BFE /* PBXTargetDependency */,
+				04490844295D6074ADF96D3644CBAC20 /* PBXTargetDependency */,
 			);
 			name = "Nimble-Snapshots";
 			productName = Nimble_Snapshots;
@@ -2470,7 +2470,7 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		185B030FC939AD85A448F5B02AA405E5 /* Resources */ = {
+		08208358CDD4D535318A465FC8AA88FF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2484,13 +2484,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1E5E12160907B8C2045D575F159F2FA4 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		1E63FAB02F8CF5DED28BE090E8C76805 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2498,14 +2491,35 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2EFC5067985A8C19BC6A6466962C0480 /* Resources */ = {
+		25DF49B1DEFF3CC6D4EE0E603055C5D1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		64F5CF5B5D554A09754D61170C112655 /* Resources */ = {
+		390D339FBE89A0CE5E1B942A597B4CE6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		436C9C7C13D3A19686C25EFA55729A13 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		454A8E9BD3DCDE2DDBF618B3A788BDFA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4D36EA6EB43C62895258B00F3DE679A3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2526,7 +2540,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9C52AADBEA4B2AD03BD4B57ED5626DFE /* Resources */ = {
+		C10834EA848E9297E564D74BD09D1881 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2540,13 +2554,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DB48A5F7598109A057F10FE669B2786B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DD2F8EF890A5E37B15EC38485640A2AF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2554,14 +2561,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E402980A445D5B60835F0362114CADB8 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E652A384B68FA0580935A74296070630 /* Resources */ = {
+		E998E7EBC69FE2018F2953F7594E804A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2621,91 +2621,59 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4DC16C1ADD49486DB3B63C4197D574D5 /* Sources */ = {
+		1A780F7DEF58A6F1EC882601AD7BC330 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9E403C2191B0BC0D93607EAA5A769CDB /* Atomic.swift in Sources */,
-				4174582421A9C36BF50FD0C92CD1FC2D /* Chary-dummy.m in Sources */,
-				4892D1670C7EB6A1DC6EDECCBCEF4E06 /* DispatchQueue+Extensions.swift in Sources */,
+				F2630857708FA35B462A66E2EC6869B7 /* CollectionViewDiffableDataSource.swift in Sources */,
+				6F6ADDC5A714E78254EAB328A4724451 /* DiffableDataSourceCore.swift in Sources */,
+				9F01C8CA09B0513BDEA092A94AA92A3A /* DiffableDataSources-dummy.m in Sources */,
+				96C8BA2F79B77CDEDB71F166FAEF53D7 /* DiffableDataSourceSnapshot.swift in Sources */,
+				4392AC861BB01B91B9C9D041E411387B /* HashableExtension.swift in Sources */,
+				525A1C2A851EF4B3F28EC1C2956E6EDB /* MainThreadSerialDispatcher.swift in Sources */,
+				3CF2B5F6A0F69AA4FD40999F1113AB7E /* SnapshotStructure.swift in Sources */,
+				4E459BC27812C8290FEB7BF262EEE5B0 /* TableViewDiffableDataSource.swift in Sources */,
+				18EE64773F8221084D41B48EC8E414F3 /* UniversalError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6A453F628BBCF73EFFDB4EB46B54E9EF /* Sources */ = {
+		2E35B67B7CA82CF0C0CA4E038494165E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1E4CAC9687D0CDD2099DD07647FC1CBF /* AnchorExtractable.swift in Sources */,
-				61EABFAB466BF8A6A1402694240846AA /* AnchorPair.swift in Sources */,
-				7A1BA2D46C33A517B95B684EB3EF1E05 /* Array+Extensions.swift in Sources */,
-				1C685A13B605387826E6B4759CFD34C3 /* Axis.swift in Sources */,
-				AF56411683F8BEFA2F1022B6AE755C00 /* AxisAnchor.swift in Sources */,
-				E07D988C96A2486C54A88D458A72443F /* AxisAnchorRelation.swift in Sources */,
-				2750688C04D696A233087DFE2A35EEB4 /* ConstraintBuilder.swift in Sources */,
-				F3CFCCC86D9247F7261EFA3CE9483B46 /* ConstraintBuilderRootRecoverable.swift in Sources */,
-				6504CEE9820D6B9BB796825506EAA66A /* Dimension.swift in Sources */,
-				870D61DCD277FD0F0A90F4A712841A9C /* DimensionAnchor.swift in Sources */,
-				68F639E7D3E58E1F5AE984E6D7832B3C /* DimensionAnchorRelation.swift in Sources */,
-				4FA57A8866F7E4556059CBF2CACA6C47 /* Draftsman-dummy.m in Sources */,
-				7A3D50E092FA279DD673AE2320A34466 /* Enumeration.swift in Sources */,
-				37CE2F3601D1DB9908A1E3DB64A47256 /* IdentifiedAnchorRelation.swift in Sources */,
-				EF1CD2CF2E482AE911D78FE57A16E27B /* LayoutAnchor.swift in Sources */,
-				09796942E62FDC0EC6D0C793249D1C2C /* LayoutAxisAnchor.swift in Sources */,
-				301A4F6E11CFCA852B5DBAF0769DD349 /* LayoutDraft.swift in Sources */,
-				636FE4C69452530C06EFA0A21FB6BB2E /* LayoutDraftBuilder.swift in Sources */,
-				A10190A4FEA7E53D9F66560A0A156103 /* LayoutPlan.swift in Sources */,
-				E3C91587EB8E329F11D38CAE5396C545 /* LayoutWithAnchors.swift in Sources */,
-				8EFBBB05612F069AE61988C9DF400CC4 /* NSLayoutConstraint+Extensions.swift in Sources */,
-				F194BAB9B258057E8246017258737BCB /* NSLayoutDimension+Extensions.swift in Sources */,
-				52835799BC977EF3785C1E2ADA594566 /* Pair.swift in Sources */,
-				CD4958E799D5C476B461FC9C11C05439 /* PairAnchor.swift in Sources */,
-				83E1A8E0E496C1F3D8129FC4412E32BE /* PairAnchorRelation.swift in Sources */,
-				63F06E97C680EB6DDB8D395CF72413F6 /* PairConstant.swift in Sources */,
-				6089C2C3F28210D73F3A78EFD949EC92 /* PlanComponent.swift in Sources */,
-				F5D862257F6AD6A45A2E0D2023E4B932 /* PlanContext.swift in Sources */,
-				84E944E5A0E6DF9CA19CEF6CDE604F99 /* Planned.swift in Sources */,
-				243C146D0E37AD7157F75B21F0D42FFF /* PlannedDraft.swift in Sources */,
-				F0199FBA4B66A724FB123BEC6B7B952F /* PrioritizedAnchorRelation.swift in Sources */,
-				CBB74DBB6BCD31B34EA1D86B3D23D23D /* Quad.swift in Sources */,
-				329FA1BC76AC7F220BC4F2845DD6C38D /* QuadAnchor.swift in Sources */,
-				E30E374509412D38745961534DE991BA /* QuadAnchorRelation.swift in Sources */,
-				6AC16BD6F1261A4D9ECE473A8D144944 /* Single.swift in Sources */,
-				D0DF6D2313FF6A9BE8B31FD49E7790CA /* SingleAnchor.swift in Sources */,
-				682E769B8238493BCCE5CFDDBA1B5199 /* SingleAnchorRelation.swift in Sources */,
-				73878610E166B2B725F49B6F0D1BEBBB /* SizeAnchor.swift in Sources */,
-				325E8EB1150189107142C7CCD0F109E6 /* SizeAnchorRelation.swift in Sources */,
-				ADD1923D18914005102FA3D9D9B778A5 /* StackCompatible.swift in Sources */,
-				8A34B01AD3EC82C1DC4402C75551689C /* TriAnchor.swift in Sources */,
-				8B0078AB8490C1ABA17ACC8FE35649A1 /* TriAnchorRelation.swift in Sources */,
-				6B32882C4FE34D76A85C2B90EE61EC95 /* TriConstant.swift in Sources */,
-				6267F8BDBC4D546E1BD96E7C942C7881 /* Trio.swift in Sources */,
-				6587CA6D9AF4A71B10F3DCED7BEB3C6B /* UIKit+Extensions.swift in Sources */,
-				45F6E5C9DC63E19597D2132DF77B8752 /* UIView+Extensions.swift in Sources */,
-				441BD552180843727513C0704248F69D /* ViewPlan.swift in Sources */,
-				D2C0CC317B1575A23F5659E8FC126A66 /* ViewPlanBuilder.swift in Sources */,
+				D34F3FCC98BD7511A24FDA022387E6AE /* Algorithm.swift in Sources */,
+				70DA6795B83DA31D18B2F3D5965503A7 /* AnyDifferentiable.swift in Sources */,
+				144BD31F10D9048902D4128F8021E619 /* ArraySection.swift in Sources */,
+				08E0E6C68904008ADB77F20FB4BF6B94 /* Changeset.swift in Sources */,
+				097698EE3E5EB4F6069AA2700FFCAF94 /* ContentEquatable.swift in Sources */,
+				F29E2A1D29C1D0B0375F0A28BBFBD3E9 /* ContentIdentifiable.swift in Sources */,
+				40CF0BA448F272D85CF1D2EA6F9A9AC5 /* DifferenceKit-dummy.m in Sources */,
+				FA0D61FE871DAF660589ABBC8C844037 /* Differentiable.swift in Sources */,
+				182CD8F73127C0B81CF3FDD877D7260F /* DifferentiableSection.swift in Sources */,
+				8BC3A9F393884AEC5B7825B5C46C69BC /* ElementPath.swift in Sources */,
+				81806735586A6390F80A9B0AB5E71354 /* StagedChangeset.swift in Sources */,
+				55CC56FE56AB92DE8C0A3A459238E1C1 /* UIKitExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7A30C79560203C89F07EFB803A0D1A1E /* Sources */ = {
+		46694EF8DF5E5344CF7E10A08C4DB757 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1DD09AA22EA8ECE7F0CFCB870C5B3DC5 /* Clavier-dummy.m in Sources */,
-				080AF38AC0F35D3DE6F5283FA1D97659 /* ClavierLayoutGuide.swift in Sources */,
-				9196F8ECAC419357914F0A9BAC241A0A /* Extensions.swift in Sources */,
-				47A3F0948E65C7F3EB2329D18B0E8AB5 /* SafeAreaKeyboardLayoutGuide.swift in Sources */,
+				B26FC252B21E5DEE689E9A2ABE6D8105 /* Atomic.swift in Sources */,
+				8EED37A7EB1696E084D4740EDDA2CE7C /* Chary-dummy.m in Sources */,
+				EE7AA6A8AF5BBD680CB644244326B904 /* DispatchQueue+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7A497E33DCFA844E3278B209C379B896 /* Sources */ = {
+		700EB9AEF64153938A1D77AB9EB4A0F5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				808BFDDC9CE4DAE92E67299DB188C50B /* Buildable.swift in Sources */,
-				D683AF41DC18E879253A8305B3B6EA55 /* Builder.swift in Sources */,
-				33E0E20B386F39CB7C5FBAB29195F6F6 /* Builder-dummy.m in Sources */,
-				C7ED909C9C7C014A513A6D3DCC86CD08 /* BuilderConfig.swift in Sources */,
-				7454FD321C71CA670B04FE091D02B0EC /* PropertyAssigner.swift in Sources */,
+				CD0BFFE37E2073445EF530778DACF2F9 /* Clavier-dummy.m in Sources */,
+				A279B8C38B36F85C8880488B6129598F /* ClavierLayoutGuide.swift in Sources */,
+				A37BFEAF0C23EFB8860E24D4E12E5C0E /* Extensions.swift in Sources */,
+				8D3449D41FF1CF0042903A3ED8565628 /* SafeAreaKeyboardLayoutGuide.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2786,6 +2754,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B5D405F5E3D42100667427387BBD3CC /* Array+Extensions.swift in Sources */,
+				BBA2E6EB286FD3D00055AE11 /* ViewBindable+Retaining.swift in Sources */,
 				C70B22B92E2E7F7C1FA5F6CF52B162FA /* ArrayBuilder.swift in Sources */,
 				E25932ABB6FF30911BB1B8A89826B554 /* Artisan-dummy.m in Sources */,
 				D81A78E76C17D08611D350CFE3608F18 /* Cell.swift in Sources */,
@@ -2795,12 +2764,70 @@
 				0BCD36A9D7B12BA02B78A4D3309C5CD7 /* Maker+Extensions.swift in Sources */,
 				1250A7DF6D4922FF36BBEC34BB75FEE7 /* Methods.swift in Sources */,
 				75D720009920B474A72D70CBCB086FEF /* ScrollableStackView.swift in Sources */,
+				BBF057DC2871C66F00D34444 /* Observable+Binding.swift in Sources */,
 				4836D7C1C3D6F107C083DADC2EC458EF /* Section.swift in Sources */,
 				7ABD47CB30D3EE057F74DD0B89D00EC6 /* StackBuilder.swift in Sources */,
 				3B77D36A904BE2628D5882F07545CF01 /* TypeAliases.swift in Sources */,
 				BD602583D077852FCA7918CC484E533C /* UIView+Extensions.swift in Sources */,
 				8847CB9E0ACE43510603B324C078E749 /* ViewBindable.swift in Sources */,
 				94F80BACDABCD406BB067B2C02AD8215 /* ViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8340E3FC424F641AA566C23219F58710 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				91D87C64BA4676AC1FC34F2B6985925D /* Buildable.swift in Sources */,
+				23619A507CEFFAF261379931CD7F0517 /* Builder.swift in Sources */,
+				FD8332F5BC06374E21CA5B030F40431A /* Builder-dummy.m in Sources */,
+				9D57386585F1A5A7E7ED0300A5B33ABC /* BuilderConfig.swift in Sources */,
+				7E45FB66ECBA8FF80335F6EC6D1ED5D0 /* PropertyAssigner.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B44C5FAEB80053751A2E9CDFE38621B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				460CD2831FAD3951E7F0044754D59BEF /* BaseProtocols.swift in Sources */,
+				60B38B554815AB4437F16414573E0BCE /* BindableCollection+TextInput.swift in Sources */,
+				1004587BDF3D7FD1834B2C31157CFDA1 /* BindableCollection+UIButton.swift in Sources */,
+				848AB53029C3B830B88054CCA1246E0B /* BindableCollection+UICollectionView.swift in Sources */,
+				A50DCD5438C4D60DE8C788ADD3070083 /* BindableCollection+UIControl.swift in Sources */,
+				FB10DF412AFBA6C4A9A53D94B85D5D6C /* BindableCollection+UIImageView.swift in Sources */,
+				95598D3EFFF16EB12C3F9E1AAFF12DC2 /* BindableCollection+UILabel.swift in Sources */,
+				E3D1A07FFEC8DD51E34B208B6A318253 /* BindableCollection+UIScrollView.swift in Sources */,
+				8BDFE8C686050C072A847E3C8B13F166 /* BindableCollection+UISlider.swift in Sources */,
+				AD177D4187066B142ADF73539CB87EBC /* BindableCollection+UIStackView.swift in Sources */,
+				B6DEB7E9EE7C7E6661E33C3A24E125DA /* BindableCollection+UIStepper.swift in Sources */,
+				D3A93F2A905D5166ED4E22A75212598A /* BindableCollection+UISwitch.swift in Sources */,
+				9950DE894F23901DEDA58F1FD683148A /* BindableCollection+UITableView.swift in Sources */,
+				8EB44BAB71A05ED880217F649FD0BEE5 /* BindableCollection+UIView.swift in Sources */,
+				7CD218BEF1035FF32D3346415447874C /* BindableCollectionCellView.swift in Sources */,
+				A5F8D976790F9A67FFD6BB4C4EC5C788 /* BindableKVOObservable.swift in Sources */,
+				CA760EB69F42BAB61FB19657EE7F8F38 /* BindableObservable.swift in Sources */,
+				852F00B5A1E9B85302C8EBF6A4C1B3AE /* Changes.swift in Sources */,
+				B80E43938DD8C4D02E1ED4C2C06D7E91 /* Dictionary+Extensions.swift in Sources */,
+				F473E8CED6F920C90D66718A6040697F /* FilteredObservable.swift in Sources */,
+				4A564DACDC390C751499369E6FF5B4EA /* MappedObservable.swift in Sources */,
+				0B751D880318CC75B0CCAD223A81A041 /* MergedObservable.swift in Sources */,
+				8B14D1B69B8B1DE7D4128ABEB134FCE4 /* MulticastObservable.swift in Sources */,
+				88D5B1AF0B26880CA3208CA7B4DAD7C7 /* ObjectRetainer.swift in Sources */,
+				1BFDB5EF3383E66385A818B5DF61E45C /* Observable.swift in Sources */,
+				DDA13E0574B6016EAFA8CE9544192619 /* ObservableBlock.swift in Sources */,
+				77615F639C9073C5DBFEA9DA7E4F4FE5 /* Observed.swift in Sources */,
+				30CD82097176B9713870C3A544F0DEE0 /* Pharos-dummy.m in Sources */,
+				E3536FF0730B9071967A3B8353C35981 /* PharosContext.swift in Sources */,
+				29B542FF55AA63058F239214171AE713 /* PopulatedRelays.swift in Sources */,
+				7740B6375C07754804CC3102DEEFCD93 /* Publisher.swift in Sources */,
+				9BECF91A2508A3C77D5E1D1B32FF37C6 /* RelayInvoker.swift in Sources */,
+				D2771D0749EE458B3702825DEF1D5B59 /* Retainer.swift in Sources */,
+				DA1E1B261897F2AE80ECC2F98BCDA5A3 /* RootObservable.swift in Sources */,
+				34B6CB00174B5F13C908CCF6B278573A /* Subject.swift in Sources */,
+				8D2E9B44D15CEE6A15F834C4E4A16D8A /* UIControl+Extensions.swift in Sources */,
+				E1664B9AAE9392E00711AE5B2A03B644 /* UIControlAction.swift in Sources */,
+				B6AA8499F16DB05B80ED3614EAE80E67 /* UIControlSubject.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2820,95 +2847,73 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B0EDB69C97A90159FF1806ADE3A118B5 /* Sources */ = {
+		A7F6BDE61B11C23E910B73F71762F806 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E5301341D4968B1ECFC5E30007A8B504 /* BaseProtocols.swift in Sources */,
-				2A6DBF437130D200091AACBE3FBAC4F1 /* BindableCollection+TextInput.swift in Sources */,
-				F03DE2B3F1169D0B71ADF9E6428595FC /* BindableCollection+UIButton.swift in Sources */,
-				4D5B4BF9DCF45EA57142E7CF80487F6E /* BindableCollection+UICollectionView.swift in Sources */,
-				475D873E7CBDDC3BF8F87A6295236106 /* BindableCollection+UIControl.swift in Sources */,
-				3EF19F07A10AD7D832BF2C4CE38FA8A4 /* BindableCollection+UIImageView.swift in Sources */,
-				BD7AB6BB94E45794A06B8481C87F62FF /* BindableCollection+UILabel.swift in Sources */,
-				DF2B831FA4647CBF33A78A174F4C4D9A /* BindableCollection+UIScrollView.swift in Sources */,
-				02C46487477F445C4DA95C283CECDDAD /* BindableCollection+UISlider.swift in Sources */,
-				ADDD4335306146E17016DFAC6A14760E /* BindableCollection+UIStackView.swift in Sources */,
-				35DB46D40C883E325C68BF634B42A56A /* BindableCollection+UIStepper.swift in Sources */,
-				5E168B898CA8FBB501E7D51F996BD11D /* BindableCollection+UISwitch.swift in Sources */,
-				A74AF435538B54124BA7644830495E51 /* BindableCollection+UITableView.swift in Sources */,
-				EAA0716B31E50CB0FDDFB20E2AA2B226 /* BindableCollection+UIView.swift in Sources */,
-				251802FBCBFF8E19829ED48F7C87F98E /* BindableCollectionCellView.swift in Sources */,
-				C8174F5A3EB38338601284181DF5F0A5 /* BindableKVOObservable.swift in Sources */,
-				DCCA75688121736202FD12E24F43C2E0 /* BindableObservable.swift in Sources */,
-				403F30ECDF126A9FB4B80E9FA6D75C4D /* Changes.swift in Sources */,
-				88D2A17E09B7AE99854037B566CC7BB3 /* Dictionary+Extensions.swift in Sources */,
-				8C98E99A78C8A1005E9E5C6AD0E5D411 /* FilteredObservable.swift in Sources */,
-				897F59AC1D7E12F4BFB70FC683E6E4E1 /* MappedObservable.swift in Sources */,
-				1B3A98A4E9BA1E64ABC90BE4000EC542 /* MergedObservable.swift in Sources */,
-				C60295908A3575FFE203D484560325B7 /* MulticastObservable.swift in Sources */,
-				61AADBA10A8CDEF7242F1E9D3DF77D72 /* ObjectRetainer.swift in Sources */,
-				7F19181825D8609EF99067ABDE505064 /* Observable.swift in Sources */,
-				2A4503826B8E43663C8982C8337DCAA1 /* ObservableBlock.swift in Sources */,
-				BAAF54567B513199C31BBCB2CACF639B /* Observed.swift in Sources */,
-				884B940C394CD879E18805B55EFF7181 /* Pharos-dummy.m in Sources */,
-				E18F746F2FEEA373368ED2EEB60C3FC7 /* PharosContext.swift in Sources */,
-				24D44C09E8193C89FBA84B9B6324B529 /* PopulatedRelays.swift in Sources */,
-				0219E278998DADCA6EF6CB9341079DC5 /* Publisher.swift in Sources */,
-				17101CF579A9D04C357C0D5FC85A4EC7 /* RelayInvoker.swift in Sources */,
-				59E889166FED63A0186ED35B67459977 /* Retainer.swift in Sources */,
-				8FDAB5CEFE8D633BC1E41423FF377BDF /* RootObservable.swift in Sources */,
-				FDE31A7670A75E62086CC6184105ED51 /* Subject.swift in Sources */,
+				733A21E4CE69B14047D8F387D69FAB54 /* FBSnapshotTestCase.m in Sources */,
+				92325E9EFA8C4AF3D9BFF001DC4CDE1B /* FBSnapshotTestCasePlatform.m in Sources */,
+				98453F902536AE57C2E9F394882022AA /* FBSnapshotTestController.m in Sources */,
+				FF36A2447FCB9A41A540C49E872AAEF3 /* iOSSnapshotTestCase-dummy.m in Sources */,
+				BE03E1824820C073442D86968791D2F3 /* SwiftSupport.swift in Sources */,
+				843E75198F6DD8D9B06EEED71D507EF5 /* UIImage+Compare.m in Sources */,
+				70294D4E92BB86B1854EFAC3471525CD /* UIImage+Diff.m in Sources */,
+				864CEFBA058BD399B9EAFF9A9E84757C /* UIImage+Snapshot.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B6785B35E438B18B74FA280DCB1D1951 /* Sources */ = {
+		A8ABED0585F83AAD0AD5D0963241C5E4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0AB84C171BE96A1EA8335B7B5F364D34 /* FBSnapshotTestCase.m in Sources */,
-				9CD73EE4AC05F963C515EE10F85CF4F7 /* FBSnapshotTestCasePlatform.m in Sources */,
-				B1239F7A587246442BB5544BA980D77A /* FBSnapshotTestController.m in Sources */,
-				1C820F77442AB16B7C1B6C1275339E3D /* iOSSnapshotTestCase-dummy.m in Sources */,
-				F19CE6947FBCDB8A185070C7D90709AC /* SwiftSupport.swift in Sources */,
-				0ED5A2370B4E4EB32E02579E1DDFE41D /* UIImage+Compare.m in Sources */,
-				108889297C9A0CD155B03BFA4E1D9FB4 /* UIImage+Diff.m in Sources */,
-				A098E1AD51852CF09DE1C80A6B58A352 /* UIImage+Snapshot.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDF62482F2113E46804B2A81FFB5C4D9 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7E6C9773E4826E2412FED678E1D8E36E /* CollectionViewDiffableDataSource.swift in Sources */,
-				E2D9E6C8707AF298E1B8D1C5FEF609C4 /* DiffableDataSourceCore.swift in Sources */,
-				2B0C2A3699767FF9D7298156897939B0 /* DiffableDataSources-dummy.m in Sources */,
-				927137AD29366E6595BB3F728EF8D842 /* DiffableDataSourceSnapshot.swift in Sources */,
-				DA4CF37D028D29B49C9F79076725C3F3 /* HashableExtension.swift in Sources */,
-				E7C0C525FD3F87ABFDE7E7B30E646858 /* MainThreadSerialDispatcher.swift in Sources */,
-				64A3CBD089502CA3829F5A00101CD1BF /* SnapshotStructure.swift in Sources */,
-				8316A6E428239F2AD1C11964366B5668 /* TableViewDiffableDataSource.swift in Sources */,
-				45C4D589AC10B11BDDDB3D935833037C /* UniversalError.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BFC39C50068DB72A49350D1D3FF6ED03 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				80C9C88FCA3879858AFD900FFB77A4FC /* Algorithm.swift in Sources */,
-				2304247E6E65AA1F76F281E51BB67C30 /* AnyDifferentiable.swift in Sources */,
-				4BDE92D9BF98E825391034D6C58D2727 /* ArraySection.swift in Sources */,
-				9B5BFD0363B5596EE8EE2D2E2998F527 /* Changeset.swift in Sources */,
-				CA14590491F62205BCAD8DE14A419F52 /* ContentEquatable.swift in Sources */,
-				A22A14D9C81B4C430D17B7953B603A87 /* ContentIdentifiable.swift in Sources */,
-				AA02A5A85750ADAFA89A47E566582EA8 /* DifferenceKit-dummy.m in Sources */,
-				A00D39F03D611AE6713E836F6ABD7B0C /* Differentiable.swift in Sources */,
-				9B297E4BEF3DD9716B7916ED923A3A83 /* DifferentiableSection.swift in Sources */,
-				C751EB8C93C32D7CF4E12379099DD367 /* ElementPath.swift in Sources */,
-				4B989B9468131355311F2C783C63F62B /* StagedChangeset.swift in Sources */,
-				999DA39565C49BBEC6656C2F10BE7B81 /* UIKitExtension.swift in Sources */,
+				F3C7953A86E43277393BC8D8D65B9F95 /* AnchorExtractable.swift in Sources */,
+				30F1B9F4DEE2C6014EF6AE2F538B2E62 /* AnchorPair.swift in Sources */,
+				5472E78AC4F7CB1F9187A98FAAAC3E92 /* Array+Extensions.swift in Sources */,
+				AEDE03FD8D62B73E4001FF88024E22A1 /* Axis.swift in Sources */,
+				8F60FF351D49CE3A778EC1129AD74F1D /* AxisAnchor.swift in Sources */,
+				1DE7B12D8CA0BED403F6B3ECA871A15E /* AxisAnchorRelation.swift in Sources */,
+				4A895A0E79B49EF205F51F80842AA1E6 /* ConstraintBuilder.swift in Sources */,
+				75FCBB886383B54128A1F595133F0B55 /* ConstraintBuilderRootRecoverable.swift in Sources */,
+				6D102298B810A01E5BC7448146CE189A /* Dimension.swift in Sources */,
+				24B50887629B644EF820CA9E03D7F6B5 /* DimensionAnchor.swift in Sources */,
+				C38E10DE4C9CC4EEDB7732A8A1FB6C3D /* DimensionAnchorRelation.swift in Sources */,
+				3F21CA906942CD3CCD81D62B1EE8B2D4 /* Draftsman-dummy.m in Sources */,
+				8601CB49410FE95D7B2C69717273B66B /* Enumeration.swift in Sources */,
+				6CA34960CAE04CCD19B6B554D71F5420 /* IdentifiedAnchorRelation.swift in Sources */,
+				3BEC17D28DE464767FD605261CED6DE7 /* LayoutAnchor.swift in Sources */,
+				B21FE4D322BC5A8FFB55009063F84AA7 /* LayoutAxisAnchor.swift in Sources */,
+				D4B7DC65E1C2CDA3457D008345ECF750 /* LayoutDraft.swift in Sources */,
+				97A5E63764F3624560F77789BD078F7B /* LayoutDraftBuilder.swift in Sources */,
+				554BB1A940C8663FBEDE2424F0468379 /* LayoutPlan.swift in Sources */,
+				BA02AB6527987BC123E5FD1B1136DDE0 /* LayoutWithAnchors.swift in Sources */,
+				3E8191CDB404F83CA9E632BF03A1E69F /* NSLayoutConstraint+Extensions.swift in Sources */,
+				1C42ED675A4658A6DB2FAC15BD30BE3C /* NSLayoutDimension+Extensions.swift in Sources */,
+				18A00DD98F06B4C8532DA6428CDA5E11 /* Pair.swift in Sources */,
+				359AC5C2066CF16D461B990E82720673 /* PairAnchor.swift in Sources */,
+				432D9032806A77F1A1D9BC343A92462B /* PairAnchorRelation.swift in Sources */,
+				4A425006F878F1CBC0F424626C9AA3FF /* PairConstant.swift in Sources */,
+				5FBD95B0688D536E680201096933003B /* PlanComponent.swift in Sources */,
+				7C0B227AC201698361889409EB2E91F8 /* PlanContext.swift in Sources */,
+				FB4ED8D04439915EB30AE12C61A94866 /* Planned.swift in Sources */,
+				B42224836402409706B58CF13972FDF5 /* PlannedDraft.swift in Sources */,
+				A5C635FAFD5C43B769C0C09B00203355 /* PrioritizedAnchorRelation.swift in Sources */,
+				6CB291A7D2B6B89CCBB0CD5601415E84 /* Quad.swift in Sources */,
+				DFA2F427123C018E72F6C1B1158525C6 /* QuadAnchor.swift in Sources */,
+				AA2E4FAA4AD39139F3E5B386F7D6AAE5 /* QuadAnchorRelation.swift in Sources */,
+				A15702D3B339BECA866626848EB824FF /* Single.swift in Sources */,
+				73717E7331080AC4B3E3110DE952E691 /* SingleAnchor.swift in Sources */,
+				CEBC83DD97A53E72395D7F85D09EFDE6 /* SingleAnchorRelation.swift in Sources */,
+				6E12F9555DEFB926B1F939FCCEB42732 /* SizeAnchor.swift in Sources */,
+				58B4642071DA0F1D03C35022AE6FAD8D /* SizeAnchorRelation.swift in Sources */,
+				09E9AF9AD6463B8D1474669ED9695C80 /* StackCompatible.swift in Sources */,
+				E4300F6490EC170A803AEEA8D9E55CDB /* TriAnchor.swift in Sources */,
+				DBA61AA93F2DB387B4365D37DDAD7E3E /* TriAnchorRelation.swift in Sources */,
+				74DBF3C235FEE288BC54C5ABF4BCEAEA /* TriConstant.swift in Sources */,
+				B2365E1737EB50769635809045365AA8 /* Trio.swift in Sources */,
+				C9EF5171D780B4A37745A9842FCFDEDF /* UIKit+Extensions.swift in Sources */,
+				03D16E6A4CCD534E0E79FD4E0330BFB9 /* UIView+Extensions.swift in Sources */,
+				906295CBBED92366E30F037D23100B79 /* ViewPlan.swift in Sources */,
+				BCF3FA1B96CEF82C24894BF3C97C50D7 /* ViewPlanBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2966,165 +2971,164 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		04CE65B0EEFDA29480D48E779B923160 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Clavier;
-			target = A0746DCD7C48E9F6BAB723766294323A /* Clavier */;
-			targetProxy = 9EF17C7586CC06AE22A69BA0827079D4 /* PBXContainerItemProxy */;
-		};
-		1C3A98138C988AEDAE62487B98E174D2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DiffableDataSources;
-			target = 222C9BA9370230B670273F42B5E7F810 /* DiffableDataSources */;
-			targetProxy = 0287288EDAB12EDE41DCE9A15D774436 /* PBXContainerItemProxy */;
-		};
-		23BFC76C865622EB9FF5E1953AE4AF8A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Pharos;
-			target = 0DED92290FC5B4F771B42870DB0A2D55 /* Pharos */;
-			targetProxy = 05CED05DF0E3231BEA9C1B0C0E90FB5D /* PBXContainerItemProxy */;
-		};
-		24B7AC682016E67EC8DC72A645848C7C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Draftsman;
-			target = 6A3AC2D6739DCB3DEBEB81CF81B207F2 /* Draftsman */;
-			targetProxy = AE10E0E494C69F672AA2DB3736CD6F82 /* PBXContainerItemProxy */;
-		};
-		31F01DA61D5E4A89B5BD504E83A1F38A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = iOSSnapshotTestCase;
-			target = C393038B0BEF088C1B93E6528005862D /* iOSSnapshotTestCase */;
-			targetProxy = 2C1E7861209B7701A7342F873A7F0480 /* PBXContainerItemProxy */;
-		};
-		34FB332E56F256B442B73E3B5BA5AE2D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Quick;
-			target = C82891EAB7293DBEE916B21F57E8474D /* Quick */;
-			targetProxy = 44C5E4C29257D75DF99C73129D4A253E /* PBXContainerItemProxy */;
-		};
-		4B684637E1D1DB26BB4B8BD445162032 /* PBXTargetDependency */ = {
+		01BE9D940237F72462BE78BB50E94290 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = DifferenceKit;
 			target = 8FC6E51285E4FD828A61BEFD2100CD64 /* DifferenceKit */;
-			targetProxy = D8BA7D686AF2DC6BBA10E559D4E5FDD4 /* PBXContainerItemProxy */;
+			targetProxy = F4BAAA470153DACB45D7408458B3A05B /* PBXContainerItemProxy */;
 		};
-		4CE7547275D2E2FEE576C169F2ECF319 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Builder;
-			target = ED7AB6873A9DA430A18E0109776D3707 /* Builder */;
-			targetProxy = D6E9860B3160EB961354B058DBED7686 /* PBXContainerItemProxy */;
-		};
-		5EA0FA8A4B492D566C73187025589D0A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Builder;
-			target = ED7AB6873A9DA430A18E0109776D3707 /* Builder */;
-			targetProxy = D0D8CC918A91E9375D5C987E29E53F0A /* PBXContainerItemProxy */;
-		};
-		5FD671EFC527C5D6C11F538BA4DC7E35 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Nimble;
-			target = 6F13695E06195A78EA8A95F8C7ED0D2F /* Nimble */;
-			targetProxy = E07B96CDC104AA6AC6324D70DFC2105C /* PBXContainerItemProxy */;
-		};
-		6C15B350CA39AE6F98A79C6D98B43CAA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = iOSSnapshotTestCase;
-			target = C393038B0BEF088C1B93E6528005862D /* iOSSnapshotTestCase */;
-			targetProxy = A573CF3FF90D9016597EC395258A8A80 /* PBXContainerItemProxy */;
-		};
-		7D7C6AB1B9F24EFE11A98A3B0DD4E78F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Builder;
-			target = ED7AB6873A9DA430A18E0109776D3707 /* Builder */;
-			targetProxy = 8193BCA66065396ABFDE383DD4230213 /* PBXContainerItemProxy */;
-		};
-		818C2030320E3A76D6B42B42BD22EB08 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-Artisan_Example";
-			target = 4C2EE813FA11F65A8F53AAB9A84C6E08 /* Pods-Artisan_Example */;
-			targetProxy = E71E455E04580E059886BDFB341008B8 /* PBXContainerItemProxy */;
-		};
-		87664F465470ECDBAFE0A8D2F8B146F8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Draftsman;
-			target = 6A3AC2D6739DCB3DEBEB81CF81B207F2 /* Draftsman */;
-			targetProxy = 3805407BF13FCA437BF46327E5860AC0 /* PBXContainerItemProxy */;
-		};
-		89777068F344848573143C5629E8EDCF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Impose;
-			target = 085BD8B607F192AF5EA09EA6EB2E7801 /* Impose */;
-			targetProxy = 6FC24FD0A3F937F420E1A98443C58827 /* PBXContainerItemProxy */;
-		};
-		8DBDBCE830653DF7F29E425E9DBA81AE /* PBXTargetDependency */ = {
+		01E322EB23222747959C972AECDF48FB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = FBSnapshotTestCase;
 			target = 98A98149697C80CEF8D5772791E92E66 /* FBSnapshotTestCase */;
-			targetProxy = 681720131352C45062887FF260FFE12E /* PBXContainerItemProxy */;
+			targetProxy = 568CD903A5533598372D90D7361B8309 /* PBXContainerItemProxy */;
 		};
-		95D4890FB7D9F127534D00C8EC50CF62 /* PBXTargetDependency */ = {
+		04490844295D6074ADF96D3644CBAC20 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = iOSSnapshotTestCase;
+			target = C393038B0BEF088C1B93E6528005862D /* iOSSnapshotTestCase */;
+			targetProxy = 7B2928FD99A06E3F1E96D406B7631FC5 /* PBXContainerItemProxy */;
+		};
+		1A9D11D91A5B261FE69111B4C97424D1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Pharos;
 			target = 0DED92290FC5B4F771B42870DB0A2D55 /* Pharos */;
-			targetProxy = 9164A560FA5927F6A315EBE6B30739AE /* PBXContainerItemProxy */;
+			targetProxy = B62A26508AD0B164EB7FE34A6B7DDAAE /* PBXContainerItemProxy */;
 		};
-		B25D17765D18E3EF7A1243C6F56751A1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Chary;
-			target = E4D0DCAA1CEF50B24DB0FE6DB58A775E /* Chary */;
-			targetProxy = DA4F6FE206856C654A09E703046B819E /* PBXContainerItemProxy */;
-		};
-		C02B1999C7ECD17ABE7FAFB452BC8106 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DiffableDataSources;
-			target = 222C9BA9370230B670273F42B5E7F810 /* DiffableDataSources */;
-			targetProxy = EFAC8CC4024512658E0745D53FC7F5F7 /* PBXContainerItemProxy */;
-		};
-		C489F4CCBAAFF50691F802F58A972035 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Nimble;
-			target = 6F13695E06195A78EA8A95F8C7ED0D2F /* Nimble */;
-			targetProxy = 514D201F6B22558AD840030086B260F4 /* PBXContainerItemProxy */;
-		};
-		D53C15FB96FA249B0CB8A960746B7C79 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Chary;
-			target = E4D0DCAA1CEF50B24DB0FE6DB58A775E /* Chary */;
-			targetProxy = AE2650D4E6EFDB14BDB1F691C140ABEB /* PBXContainerItemProxy */;
-		};
-		E098B94DE510B3F53A54E960F873BF79 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Nimble-Snapshots";
-			target = EE19095A8C98E0BC5774005673495238 /* Nimble-Snapshots */;
-			targetProxy = 31CBC2A6B79E05C60033F01490181331 /* PBXContainerItemProxy */;
-		};
-		E43A16FA7F89D858359C45F25E6FBF9C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Artisan;
-			target = E2D1FAC32F648BB9D26C11B8F69E8326 /* Artisan */;
-			targetProxy = 6A86163777D8391846C16F10582A5EE4 /* PBXContainerItemProxy */;
-		};
-		E667E2E52BA9D12EDD4494B13517F440 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DifferenceKit;
-			target = 8FC6E51285E4FD828A61BEFD2100CD64 /* DifferenceKit */;
-			targetProxy = 15EEBB0B6587881440BF4B130989656C /* PBXContainerItemProxy */;
-		};
-		E905106CDB1EB0B883495615F83ED435 /* PBXTargetDependency */ = {
+		2A0F94059E4EA0A41943012DF587A59A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Clavier;
 			target = A0746DCD7C48E9F6BAB723766294323A /* Clavier */;
-			targetProxy = D4DC9F7EF5EAE66BBF32F924F65C7316 /* PBXContainerItemProxy */;
+			targetProxy = C6BA210675AB2B8905F3BE18340FA335 /* PBXContainerItemProxy */;
+		};
+		2CDACDBF90492629D162D67394BA5A84 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = DifferenceKit;
+			target = 8FC6E51285E4FD828A61BEFD2100CD64 /* DifferenceKit */;
+			targetProxy = 36752B5F11C87BBE88E9091B0378367D /* PBXContainerItemProxy */;
+		};
+		31E98164A7CC577EDC385E6B286097CF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Draftsman;
+			target = 6A3AC2D6739DCB3DEBEB81CF81B207F2 /* Draftsman */;
+			targetProxy = 939E67157170BAF52E9D55FB821F4FD6 /* PBXContainerItemProxy */;
+		};
+		32CF5171AB7BA4CDB118E3200D9EE986 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Nimble;
+			target = 6F13695E06195A78EA8A95F8C7ED0D2F /* Nimble */;
+			targetProxy = FD0CA0E2513006FF3E6A0387C5C91416 /* PBXContainerItemProxy */;
+		};
+		3539F2BD308AF59CD097062A1CA2D688 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Pharos;
+			target = 0DED92290FC5B4F771B42870DB0A2D55 /* Pharos */;
+			targetProxy = EF9741B1F5322EDC41EB77599001D9C7 /* PBXContainerItemProxy */;
+		};
+		392ECC40386E21738C93795C2598CF24 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Builder;
+			target = ED7AB6873A9DA430A18E0109776D3707 /* Builder */;
+			targetProxy = 8BF622F0B337A4C958E30F816EF49D3E /* PBXContainerItemProxy */;
+		};
+		3D0182BC7E8F03B3B7B823D066759ED5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Draftsman;
+			target = 6A3AC2D6739DCB3DEBEB81CF81B207F2 /* Draftsman */;
+			targetProxy = 48810CF178C0F8027956FB95975DF1C7 /* PBXContainerItemProxy */;
+		};
+		3D47D9C845592DF8AD31E591DC8863F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Clavier;
+			target = A0746DCD7C48E9F6BAB723766294323A /* Clavier */;
+			targetProxy = 27565631321124B417A91FBE84218F0E /* PBXContainerItemProxy */;
+		};
+		5C484E93931C3E028C5AF13945A4E414 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Chary;
+			target = E4D0DCAA1CEF50B24DB0FE6DB58A775E /* Chary */;
+			targetProxy = E6C0BD6C36ADF20FF68138EA443C90E6 /* PBXContainerItemProxy */;
+		};
+		613A0A2634FBBFECFD4A7FAF7A4BAD5E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Builder;
+			target = ED7AB6873A9DA430A18E0109776D3707 /* Builder */;
+			targetProxy = 4873377312149BE354E102C915A19633 /* PBXContainerItemProxy */;
+		};
+		7C87FE82FC361B39727A74F731D0971B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = DiffableDataSources;
+			target = 222C9BA9370230B670273F42B5E7F810 /* DiffableDataSources */;
+			targetProxy = B51F84987B92D4591387E644DD5B6BB5 /* PBXContainerItemProxy */;
+		};
+		80E9ED7D99C3AA0BEA9826EBC28E1AB7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Nimble-Snapshots";
+			target = EE19095A8C98E0BC5774005673495238 /* Nimble-Snapshots */;
+			targetProxy = 46F2B4762745DEB020A8267559446C4B /* PBXContainerItemProxy */;
+		};
+		8B8AFE15C44232E9D3234CDBB9B32BFE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Nimble;
+			target = 6F13695E06195A78EA8A95F8C7ED0D2F /* Nimble */;
+			targetProxy = 4421E8C02A6056CCA36CD72FAEE3CF51 /* PBXContainerItemProxy */;
+		};
+		927EE8EF5E5D4542F18DF6D20FC2CBAB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Impose;
+			target = 085BD8B607F192AF5EA09EA6EB2E7801 /* Impose */;
+			targetProxy = C7378233E0CD188BF1E1097AB3CBD3A8 /* PBXContainerItemProxy */;
+		};
+		95750BFAB2770255C93B4C6C24FA7938 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = iOSSnapshotTestCase;
+			target = C393038B0BEF088C1B93E6528005862D /* iOSSnapshotTestCase */;
+			targetProxy = 0F42D60C77065D3C2C1B9E7408C76D0A /* PBXContainerItemProxy */;
+		};
+		A3797D01916CF98F55C6B712D2982395 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Chary;
+			target = E4D0DCAA1CEF50B24DB0FE6DB58A775E /* Chary */;
+			targetProxy = DEB04FA9A67580AAD44BC41BEDCF7B35 /* PBXContainerItemProxy */;
+		};
+		A7412B1A142ADF06B1BFACAEC33F2A76 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = DiffableDataSources;
+			target = 222C9BA9370230B670273F42B5E7F810 /* DiffableDataSources */;
+			targetProxy = 85F6539C30D7117473700A85F141A099 /* PBXContainerItemProxy */;
+		};
+		B7613C002909264A75CE3860A3EAF790 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Quick;
+			target = C82891EAB7293DBEE916B21F57E8474D /* Quick */;
+			targetProxy = BF91963989AE3ED71181993B7B82CB10 /* PBXContainerItemProxy */;
+		};
+		BB6F9342C4083B4AAE9390439011515C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Artisan;
+			target = E2D1FAC32F648BB9D26C11B8F69E8326 /* Artisan */;
+			targetProxy = 520A3E35B1BDF1C8AB5F47EB3D1168B1 /* PBXContainerItemProxy */;
+		};
+		F2B49146A3503FE13BBEF39FAA0892D3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Artisan_Example";
+			target = 4C2EE813FA11F65A8F53AAB9A84C6E08 /* Pods-Artisan_Example */;
+			targetProxy = 9EE0E6FE8AB87667AEDADEAFE1FDE54D /* PBXContainerItemProxy */;
+		};
+		FC64E791B39BAB9A7A95F3392B52F962 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Builder;
+			target = ED7AB6873A9DA430A18E0109776D3707 /* Builder */;
+			targetProxy = B28B3AD0172DF35C742F9D0172DB4425 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		03F5FAC5A8523C9A4BA3E008547E606D /* Debug */ = {
+		06AE6DD6C3B0EF1E841090D7B40C1283 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A3AA5F11B867859F29682198585A3A3C /* Draftsman.debug.xcconfig */;
+			baseConfigurationReference = 7BBF38670333C8645413823A58DF3ACC /* DifferenceKit.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
@@ -3133,18 +3137,18 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Draftsman/Draftsman-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Draftsman/Draftsman-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/DifferenceKit/DifferenceKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/DifferenceKit/DifferenceKit-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Draftsman/Draftsman.modulemap";
-				PRODUCT_MODULE_NAME = Draftsman;
-				PRODUCT_NAME = Draftsman;
+				MODULEMAP_FILE = "Target Support Files/DifferenceKit/DifferenceKit.modulemap";
+				PRODUCT_MODULE_NAME = DifferenceKit;
+				PRODUCT_NAME = DifferenceKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.5;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -3183,41 +3187,9 @@
 			};
 			name = Debug;
 		};
-		1D08C44222704BEC6B37CC4B309671F2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = EAE3ECC13C5B9B6D608F1D3C4D12FA97 /* Pharos.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Pharos/Pharos-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pharos/Pharos-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pharos/Pharos.modulemap";
-				PRODUCT_MODULE_NAME = Pharos;
-				PRODUCT_NAME = Pharos;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.5;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		2496B3F9E2168B2D23C6076B3E4A6E17 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7CA99F85DB68C7BBF5356E0AD2292AFF /* FBSnapshotTestCase.debug.xcconfig */;
+			baseConfigurationReference = A872E37B3AC6FF303E2FD94E65FC19AF /* FBSnapshotTestCase.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3246,9 +3218,9 @@
 			};
 			name = Debug;
 		};
-		2576A647DD75288F676C3CE77ED79841 /* Debug */ = {
+		251D00B48ABA2AFB6F035CA033EBFEEE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B0AE796C235D92E193ECAB844FAEC5D7 /* Clavier.debug.xcconfig */;
+			baseConfigurationReference = 775ED9FA2E33C3C4F22F7ABA1AEC19CC /* Chary.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3260,56 +3232,23 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Clavier/Clavier-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Clavier/Clavier-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Chary/Chary-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Chary/Chary-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Clavier/Clavier.modulemap";
-				PRODUCT_MODULE_NAME = Clavier;
-				PRODUCT_NAME = Clavier;
+				MODULEMAP_FILE = "Target Support Files/Chary/Chary.modulemap";
+				PRODUCT_MODULE_NAME = Chary;
+				PRODUCT_NAME = Chary;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
+				SWIFT_VERSION = 5.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
-		};
-		261BC6945BBD7A58E7519303E0DDD7AC /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 48477023D234FAAC61E96CA0555A8495 /* Draftsman.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Draftsman/Draftsman-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Draftsman/Draftsman-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Draftsman/Draftsman.modulemap";
-				PRODUCT_MODULE_NAME = Draftsman;
-				PRODUCT_NAME = Draftsman;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.5;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
 		};
 		2B9E26EAE2CD392AD762421F663075A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3377,9 +3316,41 @@
 			};
 			name = Debug;
 		};
-		3AD06E34346ACE77EEABA14CF3FCC7CD /* Debug */ = {
+		365BB8ABE74642B64F4863C79196D2A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 24B83A3AEA7348855B89ABB3FCC6249F /* Chary.debug.xcconfig */;
+			baseConfigurationReference = AC521E5EC20BD9EBDCEE402A29B7E1D2 /* Draftsman.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Draftsman/Draftsman-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Draftsman/Draftsman-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Draftsman/Draftsman.modulemap";
+				PRODUCT_MODULE_NAME = Draftsman;
+				PRODUCT_NAME = Draftsman;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		37FE8C8A58759AD78DD9C15EEF1638B0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F782AB11AD5E9B56FD9A59B972E00D65 /* Chary.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3404,77 +3375,15 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
-		};
-		3AEA9F0B7D6B871E3DDB8BE2B3D6BEB8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A8E54C170A37B2E5EDAE907822146532 /* DiffableDataSources.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/DiffableDataSources/DiffableDataSources-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources.modulemap";
-				PRODUCT_MODULE_NAME = DiffableDataSources;
-				PRODUCT_NAME = DiffableDataSources;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		3F2B65BF18CE6760C88405136981EA14 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1F4C05F15B014CDEFA1D8CE40D529B2D /* Builder.debug.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Builder/Builder-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Builder/Builder-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Builder/Builder.modulemap";
-				PRODUCT_MODULE_NAME = Builder;
-				PRODUCT_NAME = Builder;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
+			name = Release;
 		};
 		4D2D4A5B1E3B4C9C7BBA3F8A574C0C4F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 78C08F3164FC77E466D6A3CD454C74E5 /* FBSnapshotTestCase.release.xcconfig */;
+			baseConfigurationReference = 5BE773968DFE2AB171E4732B22BA4372 /* FBSnapshotTestCase.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3506,7 +3415,7 @@
 		};
 		587E01B0F5792CA9BFB972CA0E192872 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7048EAB14F18A05F850568C13C63F3EC /* Impose.debug.xcconfig */;
+			baseConfigurationReference = 55F88247D714C9BCECBBF8652FE7C349 /* Impose.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3538,7 +3447,7 @@
 		};
 		5917EB3FD7FBCFD309E40A3F7DA09AB1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6B731C52788415156A8F37A1F6B32281 /* Nimble-Snapshots.release.xcconfig */;
+			baseConfigurationReference = 5229633E4CDE069F5A7E47E563E10F22 /* Nimble-Snapshots.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3571,7 +3480,7 @@
 		};
 		5BD7DF7AE52C363EF4A7DF144DD5F931 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 53C80243E51F301DB348092DB75C211C /* Nimble.debug.xcconfig */;
+			baseConfigurationReference = 736AD2086D82A47487CAE44FF912DFB8 /* Nimble.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3598,39 +3507,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
-		};
-		62170ADDA0482CF97DECB145E0533D26 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7D324A4C7A3320D7A3B34F8591B04F2C /* iOSSnapshotTestCase.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/iOSSnapshotTestCase/iOSSnapshotTestCase-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/iOSSnapshotTestCase/iOSSnapshotTestCase-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/iOSSnapshotTestCase/iOSSnapshotTestCase.modulemap";
-				PRODUCT_MODULE_NAME = FBSnapshotTestCase;
-				PRODUCT_NAME = FBSnapshotTestCase;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
 		};
 		63FAF33E1C55B71A5F5A8B3CC8749F99 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3687,48 +3563,15 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Release;
 		};
-		6465E5768BF377FC36DE2FC8E08F05B8 /* Release */ = {
+		65253F066A79F18F8DDBC93F51034452 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 13FFBC3C3BAA8B2193C0EA67D52B6BCA /* DifferenceKit.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/DifferenceKit/DifferenceKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/DifferenceKit/DifferenceKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/DifferenceKit/DifferenceKit.modulemap";
-				PRODUCT_MODULE_NAME = DifferenceKit;
-				PRODUCT_NAME = DifferenceKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		6AFB68D56E8457617B4B5A8933739A3F /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 419B1E0D34FBB374618C2B9B4F9A35CC /* Pharos.release.xcconfig */;
+			baseConfigurationReference = C7B99FB5C27E6ABFBDE288D89C281A6D /* Draftsman.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3740,14 +3583,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Pharos/Pharos-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Pharos/Pharos-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Draftsman/Draftsman-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Draftsman/Draftsman-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Pharos/Pharos.modulemap";
-				PRODUCT_MODULE_NAME = Pharos;
-				PRODUCT_NAME = Pharos;
+				MODULEMAP_FILE = "Target Support Files/Draftsman/Draftsman.modulemap";
+				PRODUCT_MODULE_NAME = Draftsman;
+				PRODUCT_NAME = Draftsman;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -3759,9 +3602,42 @@
 			};
 			name = Release;
 		};
-		6C89499F731F18AC3071AE811EDB05F0 /* Debug */ = {
+		6809D756AB65F75AF2E922A475F5D586 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946A0B6964FAE6494BC5951FA0E9913A /* iOSSnapshotTestCase.debug.xcconfig */;
+			baseConfigurationReference = A72EC3090B7CA3658DFDD0773F5DDE0A /* Clavier.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Clavier/Clavier-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Clavier/Clavier-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Clavier/Clavier.modulemap";
+				PRODUCT_MODULE_NAME = Clavier;
+				PRODUCT_NAME = Clavier;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		6EF4FEBB6C0259F952FE756ACD7562CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E8FC9766B25F6F3ED1E0A7512AF6E8D1 /* iOSSnapshotTestCase.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3790,38 +3666,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
-		};
-		74D8B5BB6D374D274AE3ED7AAFC9933D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = BC7E005E09BE55303F395B5D9AA51835 /* DiffableDataSources.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/DiffableDataSources/DiffableDataSources-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources.modulemap";
-				PRODUCT_MODULE_NAME = DiffableDataSources;
-				PRODUCT_NAME = DiffableDataSources;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
 		};
 		76A568B01D3B96A1845EB3E701AC83CB /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3890,9 +3734,41 @@
 			};
 			name = Release;
 		};
+		7B405B51B3635AC6D2A43E3BB5F22587 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E969ED978719FCE351F985AF4944D1B5 /* DiffableDataSources.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/DiffableDataSources/DiffableDataSources-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources.modulemap";
+				PRODUCT_MODULE_NAME = DiffableDataSources;
+				PRODUCT_NAME = DiffableDataSources;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		7E02862B36C4C3E2A4061EA864A1D82A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 53A8803D10A2BDE2A00EC9C3A280DE2F /* Quick.debug.xcconfig */;
+			baseConfigurationReference = 9E2354BD3A5A609612C2576D995BA8CF /* Quick.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -3920,9 +3796,9 @@
 			};
 			name = Debug;
 		};
-		7F9154A67E4F04D3D54A7A3CB7A0CF36 /* Release */ = {
+		85812D9B9C30BB6BA68BEBBC534B8E03 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3B9FE67E24DEA883C62DF820B4897052 /* Clavier.release.xcconfig */;
+			baseConfigurationReference = 0C231FEE47A69341802AA68B0EAD94DC /* iOSSnapshotTestCase.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -3934,14 +3810,14 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Clavier/Clavier-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Clavier/Clavier-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/iOSSnapshotTestCase/iOSSnapshotTestCase-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/iOSSnapshotTestCase/iOSSnapshotTestCase-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Clavier/Clavier.modulemap";
-				PRODUCT_MODULE_NAME = Clavier;
-				PRODUCT_NAME = Clavier;
+				MODULEMAP_FILE = "Target Support Files/iOSSnapshotTestCase/iOSSnapshotTestCase.modulemap";
+				PRODUCT_MODULE_NAME = FBSnapshotTestCase;
+				PRODUCT_NAME = FBSnapshotTestCase;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -3988,9 +3864,9 @@
 			};
 			name = Release;
 		};
-		969CE5F6A9207994498F4913ACCA0BE3 /* Release */ = {
+		940D7EE8031B935697CDF4A4B09B1901 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF4BFE980117902700C14D371B047753 /* Chary.release.xcconfig */;
+			baseConfigurationReference = 05D721F6DDD72B4F022CD7391B84C536 /* Builder.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -4002,24 +3878,56 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Chary/Chary-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Chary/Chary-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Builder/Builder-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Builder/Builder-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Chary/Chary.modulemap";
-				PRODUCT_MODULE_NAME = Chary;
-				PRODUCT_NAME = Chary;
+				MODULEMAP_FILE = "Target Support Files/Builder/Builder.modulemap";
+				PRODUCT_MODULE_NAME = Builder;
+				PRODUCT_NAME = Builder;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.3;
+				SWIFT_VERSION = 5.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		9908B74470DA86129ADC7C28E145A882 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D924A3A8B68F65410643D92C4DA11140 /* Pharos.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Pharos/Pharos-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pharos/Pharos-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pharos/Pharos.modulemap";
+				PRODUCT_MODULE_NAME = Pharos;
+				PRODUCT_NAME = Pharos;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		A14A1EEEF50F4B8B71283BEAB91ACD9A /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -4058,7 +3966,7 @@
 		};
 		A5BA22D4099F2DB7899F68DF2A6484DC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CCE3261E81F79A0F2C33E995E3ABFAE0 /* Nimble.release.xcconfig */;
+			baseConfigurationReference = C2A12BEA6A42BE446EED9D1986872C6E /* Nimble.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4089,7 +3997,7 @@
 		};
 		A8D2C81CB10DA8B30FFC83D2ADF7FB90 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4E00BDD6380CA33853243E54C2A817AE /* Impose.release.xcconfig */;
+			baseConfigurationReference = 4F86955306047FF945EE406376D988C7 /* Impose.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -4154,9 +4062,42 @@
 			};
 			name = Debug;
 		};
-		B83FB82FD2C925DC3830B7A9331FABEF /* Debug */ = {
+		B7D2EE95AD6D6D4D960E830C215993EB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 83D7F72D0D89433A0A38899D2491842E /* DifferenceKit.debug.xcconfig */;
+			baseConfigurationReference = 6B2F30EDF3E8E72C7722AB25C8483656 /* Pharos.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Pharos/Pharos-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Pharos/Pharos-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Pharos/Pharos.modulemap";
+				PRODUCT_MODULE_NAME = Pharos;
+				PRODUCT_NAME = Pharos;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BD5F7FA41481771BB118803A81CFB35F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E67858EC04F7B9B2532565C0063852E /* DifferenceKit.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4180,6 +4121,38 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		C7A68776727A8B53081EE5F47CB6D901 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 22688060E68A2B16A4411777150EDB18 /* DiffableDataSources.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/DiffableDataSources/DiffableDataSources-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/DiffableDataSources/DiffableDataSources.modulemap";
+				PRODUCT_MODULE_NAME = DiffableDataSources;
+				PRODUCT_NAME = DiffableDataSources;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -4187,7 +4160,7 @@
 		};
 		C7F58B5218183E8949843CF69C1CE9A5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1BFE6958271DB0C607615D388C8B94B9 /* Quick.release.xcconfig */;
+			baseConfigurationReference = 9170A982344457F661E138494928C083 /* Quick.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -4216,9 +4189,9 @@
 			};
 			name = Release;
 		};
-		D3F48A98399E5877FB55FF6A56123E44 /* Release */ = {
+		CE7F5D1B33C424796B7B31A7A3C5BAA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FBD6ADF6F2F09EE90046BA1AB6907512 /* Builder.release.xcconfig */;
+			baseConfigurationReference = 0940FBA73024E0A50FBBA91B5FCD776F /* Builder.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -4243,15 +4216,46 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
+		};
+		EB72FE7CD15ECBA4A5FA16939A00A475 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B8F529B749964D64E300B52A2769199C /* Clavier.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Clavier/Clavier-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Clavier/Clavier-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Clavier/Clavier.modulemap";
+				PRODUCT_MODULE_NAME = Clavier;
+				PRODUCT_NAME = Clavier;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.1;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		EF567A69D124E84AC87134B14225FD2F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B512C78E55A90354D479A1DA348A1184 /* Nimble-Snapshots.debug.xcconfig */;
+			baseConfigurationReference = B56A0F234860DAE5EDB3A1E1A9AC8539 /* Nimble-Snapshots.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -4284,15 +4288,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1442DC57970F4732D69AD627D656E157 /* Build configuration list for PBXNativeTarget "Clavier" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				2576A647DD75288F676C3CE77ED79841 /* Debug */,
-				7F9154A67E4F04D3D54A7A3CB7A0CF36 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		1D467AF12BCFD8263C61085D135659C3 /* Build configuration list for PBXNativeTarget "Quick" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -4302,20 +4297,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		224B5A32D8429D4FCFB5B168F2F28ED7 /* Build configuration list for PBXNativeTarget "Draftsman" */ = {
+		1ED308B9F593B904DBC11065BE23FC91 /* Build configuration list for PBXNativeTarget "Clavier" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				03F5FAC5A8523C9A4BA3E008547E606D /* Debug */,
-				261BC6945BBD7A58E7519303E0DDD7AC /* Release */,
+				EB72FE7CD15ECBA4A5FA16939A00A475 /* Debug */,
+				6809D756AB65F75AF2E922A475F5D586 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		26E7C0E7F2E9E4583CC946AAA36104D5 /* Build configuration list for PBXNativeTarget "Chary" */ = {
+		25CB2DD70DEF4041BF1FE2733DBC58BC /* Build configuration list for PBXNativeTarget "DifferenceKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3AD06E34346ACE77EEABA14CF3FCC7CD /* Debug */,
-				969CE5F6A9207994498F4913ACCA0BE3 /* Release */,
+				06AE6DD6C3B0EF1E841090D7B40C1283 /* Debug */,
+				BD5F7FA41481771BB118803A81CFB35F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4329,6 +4324,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		2C0ABECBE49CE4DC34A61870679CE1FD /* Build configuration list for PBXNativeTarget "DiffableDataSources" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C7A68776727A8B53081EE5F47CB6D901 /* Debug */,
+				7B405B51B3635AC6D2A43E3BB5F22587 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2C5BC8B8C3E11CA2BB344B87C3C7B4BF /* Build configuration list for PBXNativeTarget "Nimble-Snapshots" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -4338,20 +4342,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2FABE7B848A61FDE56023FE40476971B /* Build configuration list for PBXNativeTarget "DifferenceKit" */ = {
+		4659B122399010D6262791BEFAA4B96E /* Build configuration list for PBXNativeTarget "Pharos" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B83FB82FD2C925DC3830B7A9331FABEF /* Debug */,
-				6465E5768BF377FC36DE2FC8E08F05B8 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		4029556E7594F75B17BF38F4ED9593B9 /* Build configuration list for PBXNativeTarget "iOSSnapshotTestCase" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				6C89499F731F18AC3071AE811EDB05F0 /* Debug */,
-				62170ADDA0482CF97DECB145E0533D26 /* Release */,
+				9908B74470DA86129ADC7C28E145A882 /* Debug */,
+				B7D2EE95AD6D6D4D960E830C215993EB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4374,20 +4369,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6B4BD029EDFAD5A11C711A27E086DBA9 /* Build configuration list for PBXNativeTarget "Pharos" */ = {
+		6D06C0203D713E6308051953612686D3 /* Build configuration list for PBXNativeTarget "Chary" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1D08C44222704BEC6B37CC4B309671F2 /* Debug */,
-				6AFB68D56E8457617B4B5A8933739A3F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		6F8C3841CBC672AD2CA59FF33EA5410E /* Build configuration list for PBXNativeTarget "DiffableDataSources" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3AEA9F0B7D6B871E3DDB8BE2B3D6BEB8 /* Debug */,
-				74D8B5BB6D374D274AE3ED7AAFC9933D /* Release */,
+				251D00B48ABA2AFB6F035CA033EBFEEE /* Debug */,
+				37FE8C8A58759AD78DD9C15EEF1638B0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4401,11 +4387,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8CBD34B703B7108BE74EB4B8E330DC12 /* Build configuration list for PBXNativeTarget "Builder" */ = {
+		AEA4353485BC63226C545B91E035F1B6 /* Build configuration list for PBXNativeTarget "iOSSnapshotTestCase" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3F2B65BF18CE6760C88405136981EA14 /* Debug */,
-				D3F48A98399E5877FB55FF6A56123E44 /* Release */,
+				6EF4FEBB6C0259F952FE756ACD7562CA /* Debug */,
+				85812D9B9C30BB6BA68BEBBC534B8E03 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4415,6 +4401,24 @@
 			buildConfigurations = (
 				587E01B0F5792CA9BFB972CA0E192872 /* Debug */,
 				A8D2C81CB10DA8B30FFC83D2ADF7FB90 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B3A5B60F7F4061F2BE04D255F0A9E48B /* Build configuration list for PBXNativeTarget "Builder" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE7F5D1B33C424796B7B31A7A3C5BAA3 /* Debug */,
+				940D7EE8031B935697CDF4A4B09B1901 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B3D81A1CC4D1FA0D854FCD55DA0133D7 /* Build configuration list for PBXNativeTarget "Draftsman" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				365BB8ABE74642B64F4863C79196D2A8 /* Debug */,
+				65253F066A79F18F8DDBC93F51034452 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/Draftsman/Draftsman-Info.plist
+++ b/Example/Pods/Target Support Files/Draftsman/Draftsman-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.0.4</string>
+  <string>3.0.6</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/Pharos/Pharos-Info.plist
+++ b/Example/Pods/Target Support Files/Pharos/Pharos-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.3.1</string>
+  <string>2.3.5</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/ViewBindableSpec.swift
+++ b/Example/Tests/ViewBindableSpec.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Quick
 import Nimble
-import Artisan
+@testable import Artisan
 
 class ViewBindableSpec: QuickSpec {
     
@@ -46,7 +46,7 @@ class ViewBindableSpec: QuickSpec {
             view.bind(with: "some")
             var retained: Retained? = Retained()
             weak var weakRetained: Retained? = retained
-            view.retain(retained!)
+            view.bindingRetainer.retain(retained!)
             retained = nil
             expect(weakRetained).toNot(beNil())
             view.bind(with: "some new")

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/hainayanda/Builder.git",
         "state": {
           "branch": null,
-          "revision": "01268107ca1754c200453446699092451ed340f5",
-          "version": "1.0.4"
+          "revision": "135f18c811c2e75f4a2fc8aae5e02c6c37d8d672",
+          "version": "1.0.5"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/hainayanda/Chary.git",
         "state": {
           "branch": null,
-          "revision": "fd457cc09d2e7bd8ab27677550afdb7d15830b9e",
-          "version": "1.0.1"
+          "revision": "afcddefdd56cbd6df198382bd2c65c7998f8d240",
+          "version": "1.0.2"
         }
       },
       {
@@ -24,26 +24,8 @@
         "repositoryURL": "https://github.com/hainayanda/Clavier.git",
         "state": {
           "branch": null,
-          "revision": "fde955d2d64a1ead83f7e2275d2bf3912a62ac5e",
-          "version": "2.0.1"
-        }
-      },
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-          "version": "2.1.0"
+          "revision": "acd31f2629d20b2df77ccb440ab2cb6bc2f7cfc6",
+          "version": "2.0.2"
         }
       },
       {
@@ -69,17 +51,8 @@
         "repositoryURL": "https://github.com/hainayanda/Draftsman.git",
         "state": {
           "branch": null,
-          "revision": "69aea89f0be8584dc4d5f19e6bf828a3d2af2518",
-          "version": "3.0.4"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
-          "version": "10.0.0"
+          "revision": "4f5560ff7073e23a6d7e79680a736ff81944ca57",
+          "version": "3.0.6"
         }
       },
       {
@@ -87,17 +60,8 @@
         "repositoryURL": "https://github.com/hainayanda/Pharos.git",
         "state": {
           "branch": null,
-          "revision": "e0c40bfd05b26b7d64fb59cb46a2ec75ec8ae057",
-          "version": "2.3.1"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "f9d519828bb03dfc8125467d8f7b93131951124c",
-          "version": "5.0.1"
+          "revision": "cc7f92b5f907131a61999d0674daaffe6129ddcb",
+          "version": "2.3.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,26 +15,27 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
-        .package(url: "https://github.com/hainayanda/Draftsman.git", from: "3.0.4"),
-        .package(url: "https://github.com/hainayanda/Pharos.git", from: "2.3.1"),
-        .package(url: "https://github.com/hainayanda/Builder.git", from: "1.0.4"),
+        // uncomment this two line to test
+//        .package(url: "https://github.com/Quick/Quick.git", from: "5.0.1"),
+//        .package(url: "https://github.com/Quick/Nimble.git", from: "10.0.0"),
+        .package(url: "https://github.com/hainayanda/Draftsman.git", from: "3.0.6"),
+        .package(url: "https://github.com/hainayanda/Pharos.git", from: "2.3.5"),
         .package(url: "https://github.com/ra1028/DiffableDataSources.git", from: "0.5.0")
     ],
     targets: [
         .target(
             name: "Artisan",
-            dependencies: ["Draftsman", "Pharos", "Builder", "DiffableDataSources"],
+            dependencies: ["Draftsman", "Pharos", "DiffableDataSources"],
             path: "Artisan/Classes"
         ),
-        .testTarget(
-            name: "ArtisanTests",
-            dependencies: [
-                "Artisan", "Quick", "Nimble"
-            ],
-            path: "Example/Tests",
-            exclude: ["Info.plist"]
-        )
+        // uncomment this two line to test
+//        .testTarget(
+//            name: "ArtisanTests",
+//            dependencies: [
+//                "Artisan", "Quick", "Nimble"
+//            ],
+//            path: "Example/Tests",
+//            exclude: ["Info.plist"]
+//        )
     ]
 )


### PR DESCRIPTION
- Since some projects will have different Quick and Nimble versions, which shouldn't include in the distribution, it is now removed from dependency in the Swift Package Manager version.
- Separate binding retaining with a regular one
- Add bind to plan to simplified binding to applyPlan
- Add auto binding to simplified binding
- Removed and modified some UIControl action because its already provided by Pharos